### PR TITLE
Fix Inside modal container selection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+* Fix in modal selection issue.
+* Tested up to WP 6.7.0.
+
 ## 1.2.0
 * Fix WP upgrade 6.7 issues.
 * Add text selection shortcut functionality.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -74,6 +74,7 @@ const SearchReplaceForBlockEditor = () => {
     }
     
     const range = selection.getRangeAt(0);
+
     return targetDiv.contains(range.startContainer) && targetDiv.contains(range.endContainer);
   }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -48,17 +48,20 @@ const SearchReplaceForBlockEditor = () => {
    */
   const onSelection = () => {
     const selectedText = window.getSelection().toString();
-    const targetSelector = '.search-replace-modal';
+    const modalSelector = '.search-replace-modal';
 
-    if (selectedText && !inContainer(targetSelector)) {
+    if (selectedText && !inContainer(modalSelector)) {
       setSearchInput(selectedText);
     }
   };
 
   /**
-   * Check if the selection is made inside target container.
+   * Check if the selection is made inside target container,
+   * for e.g. the `search-replace-modal`.
    * 
-   * @param selector Target selector.
+   * @since 1.2.1
+   * 
+   * @param {string} selector Target selector.
    * 
    * @returns {boolean}
    */
@@ -71,10 +74,7 @@ const SearchReplaceForBlockEditor = () => {
     }
     
     const range = selection.getRangeAt(0);
-    const isStartInside = targetDiv.contains(range.startContainer);
-    const isEndInside = targetDiv.contains(range.endContainer);
-    
-    return isStartInside && isEndInside;
+    return targetDiv.contains(range.startContainer) && targetDiv.contains(range.endContainer);
   }
 
   /**

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -48,11 +48,34 @@ const SearchReplaceForBlockEditor = () => {
    */
   const onSelection = () => {
     const selectedText = window.getSelection().toString();
+    const targetSelector = '.search-replace-modal';
 
-    if (selectedText) {
+    if (selectedText && !inContainer(targetSelector)) {
       setSearchInput(selectedText);
     }
   };
+
+  /**
+   * Check if the selection is made inside target container.
+   * 
+   * @param selector Target selector.
+   * 
+   * @returns {boolean}
+   */
+  const inContainer = (selector) => {
+    const selection = window.getSelection();
+    const targetDiv = document.querySelector(selector);
+    
+    if (!selection.rangeCount || !targetDiv) {
+      return false;
+    }
+    
+    const range = selection.getRangeAt(0);
+    const isStartInside = targetDiv.contains(range.startContainer);
+    const isEndInside = targetDiv.contains(range.endContainer);
+    
+    return isStartInside && isEndInside;
+  }
 
   /**
    * Listen for Selection.


### PR DESCRIPTION
Previously the plugin was writing into the search input text even when the selection is made inside the modal.

**Steps to reproduce:**

1. Open the search and replace modal by clicking the icon on the top left corner.
2. Select some text inside the modal and the search input will be filled with that text i.e., should not happen.

https://github.com/user-attachments/assets/7ad95167-7e26-421b-bbc0-1da8104de3c3

This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/9).