### PR TITLE
Fix Missing Tooltip component on Search & Replace Icon hover 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.1
 * Fix in modal selection issue.
+* Fix missing tooltip component.
 * Tested up to WP 6.7.0.
 
 ## 1.2.0

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { search } from '@wordpress/icons';
 import { dispatch, select } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { Modal, TextControl, ToggleControl, Button } from '@wordpress/components';
+import { Modal, TextControl, ToggleControl, Button, Tooltip } from '@wordpress/components';
 
 import './styles/app.scss';
 
@@ -58,21 +58,21 @@ const SearchReplaceForBlockEditor = () => {
   /**
    * Check if the selection is made inside target container,
    * for e.g. the `search-replace-modal`.
-   * 
+   *
    * @since 1.2.1
-   * 
+   *
    * @param {string} selector Target selector.
-   * 
+   *
    * @returns {boolean}
    */
   const inContainer = (selector) => {
     const selection = window.getSelection();
     const targetDiv = document.querySelector(selector);
-    
+
     if (!selection.rangeCount || !targetDiv) {
       return false;
     }
-    
+
     const range = selection.getRangeAt(0);
 
     return targetDiv.contains(range.startContainer) && targetDiv.contains(range.endContainer);
@@ -224,11 +224,13 @@ const SearchReplaceForBlockEditor = () => {
   return (
     <>
       <Shortcut onKeyDown={openModal} />
-      <Button
-        icon={ search }
-        label={__('Search & Replace', 'search-replace-for-block-editor')}
-        onClick={openModal}
-      />
+      <Tooltip text={__('Search & Replace', 'search-replace-for-block-editor')}>
+        <Button
+          icon={ search }
+          label={__('Search & Replace', 'search-replace-for-block-editor')}
+          onClick={openModal}
+        />
+      </Tooltip>
       {
         isModalVisible && (
           <Modal


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/16).

When the user hovers over the Search & Replace icon, the tooltip is noticeably missing. This PR fixes this missing tooltip component so that users can see some meaningful description on hover activity.

<img width="414" alt="Screenshot 2024-11-27 at 14 21 43" src="https://github.com/user-attachments/assets/bfebf38f-abf8-4e95-89b3-251bd6f4740b">
