### PR TITLE
Fix block editor selection issue due to iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1
 * Fix in modal selection issue.
 * Fix missing tooltip component.
+* Fix block editor selection issue due to iframe.
 * Tested up to WP 6.7.0.
 
 ## 1.2.0

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,7 +6,7 @@ import { Modal, TextControl, ToggleControl, Button, Tooltip } from '@wordpress/c
 
 import './styles/app.scss';
 
-import { getAllowedBlocks, isCaseSensitive, inContainer } from './utils';
+import { getAllowedBlocks, getBlockEditorIframe, isCaseSensitive, inContainer } from './utils';
 import { Shortcut } from './shortcut';
 
 /**
@@ -61,7 +61,7 @@ const SearchReplaceForBlockEditor = () => {
    * @returns {void}
    */
   const handleSelection = () => {
-    const selectedText = window.getSelection().toString();
+    const selectedText = getBlockEditorIframe().getSelection().toString();
     const modalSelector = '.search-replace-modal';
 
     if (selectedText && !inContainer(modalSelector)) {
@@ -201,12 +201,14 @@ const SearchReplaceForBlockEditor = () => {
    * @returns {void}
    */
   useEffect(() => {
-    document.addEventListener(
+    const editor = getBlockEditorIframe();
+
+    editor.addEventListener(
       'selectionchange', handleSelection
     );
 
     return () => {
-      document.removeEventListener(
+      editor.removeEventListener(
         'selectionchange', handleSelection
       );
     };

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -170,7 +170,9 @@ export const getAppRoot = (parent) => {
 export const getBlockEditorIframe = () => {
   const editor = document.querySelector('iframe[name="editor-canvas"]');
 
-  return editor ? editor.contentDocument || editor.contentWindow.document : document;
+  return editor && editor instanceof HTMLIFrameElement
+    ? editor.contentDocument || editor.contentWindow?.document
+    : document;
 }
 
 /**

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -158,6 +158,22 @@ export const getAppRoot = (parent) => {
 };
 
 /**
+ * Get iFrame Document.
+ *
+ * Retrieves the document object of the Block Editor
+ * iframe with the name "editor-canvas".
+ *
+ * @since 1.2.1
+ *
+ * @returns {Document}
+ */
+export const getBlockEditorIframe = () => {
+  const editor = document.querySelector('iframe[name="editor-canvas"]');
+
+  return editor ? editor.contentDocument || editor.contentWindow.document : document;
+}
+
+/**
  * Check if the selection is made inside a Container,
  * for e.g. the `search-replace-modal`.
  *


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/21).

Due to the **recent WP upgrade**, we are noticing a regression with when users select a text in the Block Editor. The expected behaviour should be that it populates the search input, but unfortunately it does not. This is happening because the Block Editor contains an `iFrame` and our previous implementation in the `useEffect` hook does not adequately cater for the nested document within the `iFrame`.

This PR implements a fix by targeting the nested `iFrame` within the **Block Editor** canvas.

https://github.com/user-attachments/assets/4a30eb31-ddfe-4a80-80d3-08188eea11a0