### PR TITLE
Fix timeout issues causing Icon not to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+* Prevent timeout issues in getEditorRoot.
+
 ## 1.2.1
 * Fix in modal selection issue.
 * Fix missing tooltip component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0
+## 1.2.2
 * Fix timeout issues causing Icon not to load.
 
 ## 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-* Prevent timeout issues in getEditorRoot.
+* Fix timeout issues causing Icon not to load.
 
 ## 1.2.1
 * Fix in modal selection issue.

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -130,7 +130,7 @@ export const getEditorRoot = () => {
         resolve(root);
       }
 
-      if (elapsedTime > (10 * interval)) {
+      if (elapsedTime > (600 * interval)) {
         clearInterval(intervalId);
         reject(new Error('Unable to get Editor root container...'));
       }


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/25).

When users open a post or article, we notice that the **Search & Replace** icon sometimes do not appear. This is happening because our promise resolves too quickly before the DOM is fully loaded, **especially if the user is on a slow network**. This PR implements a fix for this issue.

**BEFORE**

<img width="318" alt="Screenshot 2024-11-29 at 15 52 47" src="https://github.com/user-attachments/assets/507b170c-8b7a-4b64-9e94-f010a8454eb8">

---

**AFTER**

<img width="326" alt="Screenshot 2024-11-29 at 16 00 59" src="https://github.com/user-attachments/assets/2eaa7bd3-c0e3-4973-a0a2-ebf32e07d555">