### PR TITLE
Fix backward compatibility issues due to WP upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+* Fix backward compatibility issues due to WP upgrade.
+
 ## 1.2.1
 * Fix in modal selection issue.
 * Fix missing tooltip component.

--- a/search-replace-for-block-editor.php
+++ b/search-replace-for-block-editor.php
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
  *
  * @since 1.0.0
  * @since 1.0.2 Load asset via plugin directory URL.
- * @since 1.3.0 Localise WP version.
+ * @since 1.2.2 Localise WP version.
  *
  * @wp-hook 'enqueue_block_editor_assets'
  */

--- a/search-replace-for-block-editor.php
+++ b/search-replace-for-block-editor.php
@@ -25,10 +25,13 @@ if ( ! defined( 'WPINC' ) ) {
  *
  * @since 1.0.0
  * @since 1.0.2 Load asset via plugin directory URL.
+ * @since 1.3.0 Localise WP version.
  *
  * @wp-hook 'enqueue_block_editor_assets'
  */
 add_action( 'enqueue_block_editor_assets', function() {
+	global $wp_version;
+
 	wp_enqueue_script(
 		'search-replace-for-block-editor',
 		trailingslashit( plugin_dir_url( __FILE__ ) ) . 'dist/app.js',
@@ -52,6 +55,14 @@ add_action( 'enqueue_block_editor_assets', function() {
 		'search-replace-for-block-editor',
 		'search-replace-for-block-editor',
 		plugin_dir_path( __FILE__ ) . 'languages'
+	);
+
+	wp_localize_script(
+		'search-replace-for-block-editor',
+		'srfbe',
+		[
+			'wpVersion' => $wp_version,
+		]
 	);
 } );
 

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,4 +1,5 @@
-.editor-header__toolbar {
+.editor-header__toolbar,
+.edit-post-header__toolbar {
 	& > * {
 		order: 2;
 	}
@@ -48,7 +49,7 @@
 	}
 }
 
-.version-6-6-2 {
+body:not([class*='version-6-7-']) {
 	#search-replace {
 		margin-left: 8.5px;
 		margin-right: -11px;

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  var srfbe: {
+    wpVersion: string;
+  };
+}
+
+export {};

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -203,9 +203,9 @@ export const inContainer = (selector) => {
 }
 
 /**
- * Check if is WP version.
+ * Check if it's up to WP version.
  *
- * @since 1.3.0
+ * @since 1.2.2
  *
  * @param {string} version WP Version.
  * @returns {boolean}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -213,5 +213,5 @@ export const inContainer = (selector) => {
 const isWpVersion = (version) => {
   const { wpVersion } = srfbe;
 
-  return parseInt(wpVersion) * 100 < parseInt(version) * 100
+  return parseInt(version) * 100 >= parseInt(wpVersion) * 100;
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -120,10 +120,14 @@ export const getEditorRoot = () => {
   let elapsedTime = 0;
   const interval = 100;
 
+  const selector = isWpVersion('6.7.0')
+    ? '.editor-header__toolbar'
+    : '.edit-post-header__toolbar';
+
   return new Promise((resolve, reject) => {
     const intervalId = setInterval(() => {
       elapsedTime += interval;
-      const root = document.getElementById('editor').querySelector('.editor-header__toolbar');
+      const root = document.getElementById('editor').querySelector(selector);
 
       if (root) {
         clearInterval(intervalId);
@@ -196,4 +200,18 @@ export const inContainer = (selector) => {
   const range = selection.getRangeAt(0);
 
   return targetDiv.contains(range.startContainer) && targetDiv.contains(range.endContainer);
+}
+
+/**
+ * Check if is WP version.
+ *
+ * @since 1.3.0
+ *
+ * @param {string} version WP Version.
+ * @returns {boolean}
+ */
+const isWpVersion = (version) => {
+  const { wpVersion } = srfbe;
+
+  return parseInt(wpVersion) * 100 < parseInt(version) * 100
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -127,7 +127,7 @@ export const getEditorRoot = () => {
   return new Promise((resolve, reject) => {
     const intervalId = setInterval(() => {
       elapsedTime += interval;
-      const root = document.getElementById('editor').querySelector(selector);
+      const root = document.querySelector(selector);
 
       if (root) {
         clearInterval(intervalId);

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -223,3 +223,21 @@ const isWpVersion = (version) => {
 
   return ! (sysVersion < argVersion);
 }
+
+/**
+ * Given an array of numbers, get the Radix
+ * (converted to base 10). For e.g. [5, 6, 1] becomes
+ * 561 or [2, 7, 4] becomes 274.
+ *
+ * @since 1.2.2
+ *
+ * @param {number[]} values Array of +ve Numbers.
+ * @returns {number}
+ */
+export const getNumberToBase10 = (values) => {
+  const radix = values.reduce((sum, value, index) => {
+    return sum + (value * Math.pow(10, ((values.length - 1) - index)));
+  }, 0);
+
+  return radix;
+}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -213,5 +213,13 @@ export const inContainer = (selector) => {
 const isWpVersion = (version) => {
   const { wpVersion } = srfbe;
 
-  return parseInt(version) * 100 >= parseInt(wpVersion) * 100;
+  const argVersion = getNumberToBase10(
+    version.split('.').map(Number)
+  );
+
+  const sysVersion = getNumberToBase10(
+    wpVersion.split('.').map(Number)
+  );
+
+  return ! (sysVersion < argVersion);
 }


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/27).

We are seeing a regression for users with WP versions below `6.7.0`, when users open a post or page, the **Search & Replace** icon at the top left appears to be missing for them.

This is happening because WP officially changed some of the Block Editor classes after the recent upgrade and the class selectors we previously injected our React DOM changed from `edit-post-header__toolbar` to `editor-header__toolbar`. This PR implements a fix that ensures it works for both versions (**before** and **after**).

**AFTER**

<img width="326" alt="Screenshot 2024-11-29 at 16 00 59" src="https://github.com/user-attachments/assets/2eaa7bd3-c0e3-4973-a0a2-ebf32e07d555">