### PR TITLE
Fix style issues in WP 6.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.2
+* Fix style issues for WP 6.6.2.
+
 ## 1.2.1
 * Fix in modal selection issue.
 * Fix missing tooltip component.

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -47,3 +47,10 @@
 		}
 	}
 }
+
+.version-6-6-2 {
+	#search-replace {
+		margin-left: 8.5px;
+		margin-right: -11px;
+	}
+}


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/30).

In older versions of WP for e.g. `6.6.2`, we can see that the **Search & Replace** icon is not styled correctly and appears to be **too close** to the WordPress box icon and **too far way** from the other icons.

## Testing Instructions

- Load a WP instance version of `6.6.2`.
- Create a post or page.
- The **Search & Replace** icon should now be styled correctly:

**BEFORE**

<img width="318" alt="Screenshot 2024-12-01 at 17 40 31" src="https://github.com/user-attachments/assets/075d618d-5e7c-48ad-b63e-1ee1d557d267">

---

**AFTER**

<img width="326" alt="Screenshot 2024-12-01 at 17 46 14" src="https://github.com/user-attachments/assets/28d486d5-964c-4d05-acea-26d82bd10968">