### PR TITLE
Chore: Apply coding standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix style issues for WP 6.6.2.
 * Fix timeout issues causing Icon not to load.
 * Fix backward compatibility issues due to WP upgrade.
+* Apply coding standards.
 
 ## 1.2.1
 * Fix in modal selection issue.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -60,9 +60,9 @@ const SearchReplaceForBlockEditor = () => {
    *
    * @returns {void}
    */
-  const handleSelection = () => {
-    const selectedText = getBlockEditorIframe().getSelection().toString();
-    const modalSelector = '.search-replace-modal';
+  const handleSelection = (): void => {
+    const selectedText: string = getBlockEditorIframe().getSelection().toString();
+    const modalSelector: string = '.search-replace-modal';
 
     if (selectedText && !inContainer(modalSelector)) {
       setSearchInput(selectedText);
@@ -77,6 +77,7 @@ const SearchReplaceForBlockEditor = () => {
    * @since 1.1.0
    *
    * @param {boolean} newValue
+   * @returns {void}
    */
   const handleCaseSensitive = (newValue: boolean): void => {
     setCaseSensitive( newValue );
@@ -97,7 +98,7 @@ const SearchReplaceForBlockEditor = () => {
       return;
     }
 
-    const pattern = new RegExp(
+    const pattern: RegExp = new RegExp(
       `(?<!<[^>]*)${searchInput}(?<![^>]*<)`,
       isCaseSensitive() || caseSensitive ? 'g' : 'gi'
     );
@@ -116,12 +117,12 @@ const SearchReplaceForBlockEditor = () => {
    * @since 1.0.1 Handle edge-cases for quote, pullquote & details block.
    *
    * @param {Object} element Gutenberg editor block.
-   * @param {string} pattern Search pattern.
+   * @param {RegExp} pattern Search pattern.
    * @param {string} text    Replace pattern.
    *
    * @returns {void}
    */
-  const recursivelyReplace = (element, pattern, text) => {
+  const recursivelyReplace = (element, pattern, text): void => {
     if (getAllowedBlocks().indexOf(element.name) !== -1) {
       const args = { element, pattern, text };
 
@@ -160,7 +161,7 @@ const SearchReplaceForBlockEditor = () => {
    *
    * @returns {void}
    */
-  const replaceBlockAttribute = (args, attribute) => {
+  const replaceBlockAttribute = (args, attribute): void => {
     const { attributes, clientId } = args.element;
 
     if (undefined === attributes || undefined === attributes[attribute]) {

--- a/src/shortcut.tsx
+++ b/src/shortcut.tsx
@@ -17,7 +17,7 @@ import { getShortcut } from './utils';
  *
  * @returns {JSX.Element|null}
  */
-export const Shortcut = ({ onKeyDown }) => {
+export const Shortcut = ({ onKeyDown }): JSX.Element | null => {
   const dispatch = useDispatch();
 
   dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -114,20 +114,20 @@ export const isCaseSensitive = (): boolean => {
  *
  * @since 1.2.0
  *
- * @returns Promise<HTMLElement>
+ * @returns Promise<HTMLElement | Error>
  */
-export const getEditorRoot = () => {
-  let elapsedTime = 0;
-  const interval = 100;
+export const getEditorRoot = (): Promise<HTMLElement | Error> => {
+  let elapsedTime: number = 0;
+  const interval: number = 100;
 
-  const selector = isWpVersion('6.7.0')
+  const selector: string = isWpVersion('6.6.0')
     ? '.editor-header__toolbar'
     : '.edit-post-header__toolbar';
 
   return new Promise((resolve, reject) => {
     const intervalId = setInterval(() => {
       elapsedTime += interval;
-      const root = document.querySelector(selector);
+      const root = document.querySelector(selector) as HTMLElement | null;
 
       if (root) {
         clearInterval(intervalId);
@@ -153,8 +153,8 @@ export const getEditorRoot = () => {
  * @param {HTMLElement} parent - The Parent DOM element.
  * @returns {HTMLDivElement}
  */
-export const getAppRoot = (parent) => {
-  const container = document.createElement('div');
+export const getAppRoot = (parent: HTMLElement): HTMLDivElement => {
+  const container: HTMLDivElement = document.createElement('div');
   container.id = 'search-replace';
   parent.appendChild(container);
 
@@ -171,7 +171,7 @@ export const getAppRoot = (parent) => {
  *
  * @returns {Document}
  */
-export const getBlockEditorIframe = () => {
+export const getBlockEditorIframe = (): Document => {
   const editor = document.querySelector('iframe[name="editor-canvas"]');
 
   return editor && editor instanceof HTMLIFrameElement
@@ -186,18 +186,17 @@ export const getBlockEditorIframe = () => {
  * @since 1.2.1
  *
  * @param {string} selector Target selector.
- *
  * @returns {boolean}
  */
-export const inContainer = (selector) => {
-  const selection = window.getSelection();
-  const targetDiv = document.querySelector(selector);
+export const inContainer = (selector: string): boolean => {
+  const selection = window.getSelection() as Selection | null;
+  const targetDiv = document.querySelector(selector) as HTMLElement | null;
 
-  if (!selection.rangeCount || !targetDiv) {
+  if (!selection?.rangeCount || !targetDiv) {
     return false;
   }
 
-  const range = selection.getRangeAt(0);
+  const range: Range = selection.getRangeAt(0);
 
   return targetDiv.contains(range.startContainer) && targetDiv.contains(range.endContainer);
 }
@@ -210,14 +209,14 @@ export const inContainer = (selector) => {
  * @param {string} version WP Version.
  * @returns {boolean}
  */
-const isWpVersion = (version) => {
-  const { wpVersion } = srfbe;
+export const isWpVersion = (version: string) => {
+  const { wpVersion } = srfbe as { wpVersion: string };
 
-  const argVersion = getNumberToBase10(
+  const argVersion: number = getNumberToBase10(
     version.split('.').map(Number)
   );
 
-  const sysVersion = getNumberToBase10(
+  const sysVersion: number = getNumberToBase10(
     wpVersion.split('.').map(Number)
   );
 
@@ -231,11 +230,11 @@ const isWpVersion = (version) => {
  *
  * @since 1.2.2
  *
- * @param {number[]} values Array of +ve Numbers.
+ * @param {number[]} values Array of positive numbers.
  * @returns {number}
  */
-export const getNumberToBase10 = (values) => {
-  const radix = values.reduce((sum, value, index) => {
+export const getNumberToBase10 = (values: number[]): number => {
+  const radix: number = values.reduce((sum: number, value: number, index: number) => {
     return sum + (value * Math.pow(10, ((values.length - 1) - index)));
   }, 0);
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/32).

It ensures types are enforced for variables and methods like so:

```js
/**
 * Check if it's up to WP version.
 *
 * @since 1.2.2
 *
 * @param {string} version WP Version.
 * @returns {boolean}
 */
const isWpVersion = (version: string) => {
  const { wpVersion } = srfbe;

  const argVersion: number = getNumberToBase10(
    version.split('.').map(Number)
  );

  const sysVersion: number = getNumberToBase10(
    wpVersion.split('.').map(Number)
  );

  return ! (sysVersion < argVersion);
}
```