### PR TITLE
Fix as follow up PR on backward compatibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,17 @@
+import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
 import SearchReplaceForBlockEditor from './app';
-import { getAppRoot, getEditorRoot } from './utils'
+import { getAppRoot, getEditorRoot, isWpVersion } from './utils'
 
 (async () => {
   try {
-    const container = await getEditorRoot();
-    const app = getAppRoot(container);
-    createRoot(app).render(<SearchReplaceForBlockEditor />);
+    const app = getAppRoot(await getEditorRoot() as HTMLElement);
+    if (!isWpVersion('6.2.0')) {
+      ReactDOM.render(<SearchReplaceForBlockEditor />, app);
+    } else {
+      createRoot(app).render(<SearchReplaceForBlockEditor />);
+    }
   } catch (e) {
     console.error(e);
   }

--- a/src/shortcut.tsx
+++ b/src/shortcut.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
-import { getShortcut } from './utils';
+import { getShortcut, isWpVersion } from './utils';
 
 /**
  * Shortcut for Block Editor.
@@ -18,6 +18,10 @@ import { getShortcut } from './utils';
  * @returns {JSX.Element|null}
  */
 export const Shortcut = ({ onKeyDown }): JSX.Element | null => {
+  if (!isWpVersion('6.4.0')) {
+    return null;
+  }
+
   const dispatch = useDispatch();
 
   dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -6,10 +6,6 @@
 }
 
 #search-replace {
-	order: 1;
-	margin-left: -8.5px;
-	margin-right: 3px;
-
 	&-modal {
 		&__text-group {
 			display: flex;
@@ -49,9 +45,43 @@
 	}
 }
 
-body:not([class*='version-6-7-']) {
+body {
 	#search-replace {
-		margin-left: 8.5px;
-		margin-right: -11px;
+		order: 1;
+		z-index: 1000;
+		margin-left: -8px;
+    	margin-right: 6px;
+	}
+
+	&[class*='version-5-9-'],
+	&[class*='version-6-0-'],
+	&[class*='version-6-1-'] {
+		#search-replace {
+			margin-left: 8.5px;
+			margin-right: -26px;
+		}
+	}
+
+	&[class*='version-6-2-'],
+	&[class*='version-6-3-'],
+	&[class*='version-6-4-'] {
+		#search-replace {
+			margin-left: 8.5px;
+			margin-right: -18px;
+		}
+	}
+
+	&[class*='version-6-5-'] {
+		#search-replace {
+			margin-left: 8.5px;
+			margin-right: -14px;
+		}
+	}
+
+	&[class*='version-6-6-'] {
+		#search-replace {
+			margin-left: 8.5px;
+			margin-right: -10px;
+		}
 	}
 }


### PR DESCRIPTION
This PR is a follow up to this [PR](https://github.com/badasswp/search-and-replace/pull/28).

> We are seeing a regression for users with WP versions below `6.7.0`, when users open a post or page, the **Search & Replace** icon at the top left appears to be missing for them.

> This is happening because WP officially changed some of the Block Editor classes after the recent upgrade and the class selectors we previously injected our React DOM changed from `edit-post-header__toolbar` to `editor-header__toolbar`. This PR implements a fix that ensures it works for both versions (**before** and **after**).

**AFTER**

<img width="326" alt="Screenshot 2024-11-29 at 16 00 59" src="https://github.com/user-attachments/assets/2eaa7bd3-c0e3-4973-a0a2-ebf32e07d555">