### PR TITLE
Fix: Crashing Gutenberg Block Editor on Toggle Block Inserter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.3
+* Fix: Toggle Block UI from breaking.
+
 ## 1.2.2
 * Fix style issues for WP 6.6.2.
 * Fix timeout issues causing Icon not to load.

--- a/search-replace-for-block-editor.php
+++ b/search-replace-for-block-editor.php
@@ -45,7 +45,6 @@ add_action( 'enqueue_block_editor_assets', function() {
 			'wp-compose',
 			'wp-plugins',
 			'wp-edit-post',
-			'wp-edit-site',
 		],
 		'1.2.2',
 		false,


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/37).

## Description / Background Context

With WooCommerce installed & activated, when we click on the Toggle block inserter, the Guteberg Block editor crashes! This is happening because of the conflict with the `wp-edit-site` package. This PR fixes this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn dev`.
3. Head over to your pages or post.
4. Click on the Toggle block inserter. The Gutenberg should no more crash or break as expected like so:

https://github.com/user-attachments/assets/09167112-520c-49e4-ab93-de10b3a99e3a