### PR TITLE
Release 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1.2.3
-* Fix: Toggle Block UI from breaking.
+* Fix: Crashing Gutenberg Block Editor on Toggle Block Inserter.
+* Tested up to WP 6.7.1.
 
 ## 1.2.2
 * Fix style issues for WP 6.6.2.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-and-replace",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Search and Replace text within the Block Editor.",
   "author": "badasswp",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: badasswp, anandraj
 Tags: search, replace, text, block, editor.
 Requires at least: 6.0
 Tested up to: 6.7.1
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,10 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.2.3 =
+* Fix: Crashing Gutenberg Block Editor on Toggle Block Inserter.
+* Tested up to WP 6.7.1.
+
 = 1.2.2 =
 * Fix style issues for WP 6.6.2.
 * Fix timeout issues causing Icon not to load.

--- a/search-replace-for-block-editor.php
+++ b/search-replace-for-block-editor.php
@@ -3,7 +3,7 @@
  * Plugin Name: Search and Replace for Block Editor
  * Plugin URI:  https://github.com/badasswp/search-and-replace
  * Description: Search and Replace text within the Block Editor.
- * Version:     1.2.2
+ * Version:     1.2.3
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later


### PR DESCRIPTION
This release contains the following fixes:

- Fix: Crashing Gutenberg Block Editor on Toggle Block Inserter.
- Tested up to WP 6.7.1.