### PR TITLE
Chore: Enforce WP linting for JS files

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,5 +1,7 @@
 .babelrc
 .editorconfig
+.eslintignore
+.eslintrc.js
 .gitignore
 .github
 CHANGELOG.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 
 [*.{js,jsx,ts,tsx,json,yml,yaml,babelrc,md}]
 indent_size = 2
-indent_style = space
+indent_style = tab

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+vendor/
+build/
+dist/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: [ 'plugin:@wordpress/recommended' ],
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         yarn install
 
+    - name: Check Linting
+      run: |
+        yarn lint:js
+
     - name: Run Test Suites
       run: |
         yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Chore: Enforce WP linting across plugin.
+
 ## 1.3.0
 * Feat: Add Search count feature.
 * Tested up to WP 6.7.2.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,14 @@
-const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
-  ...baseConfig,
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: [
-    './jest.setup.js'
-  ],
-  transform: {
-    '^.+\\.jsx?$': 'babel-jest',
-  },
-  moduleNameMapper: {
-    'uuid': require.resolve('uuid'),
-  },
+	...baseConfig,
+	preset: 'ts-jest',
+	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: [ './jest.setup.js' ],
+	transform: {
+		'^.+\\.jsx?$': 'babel-jest',
+	},
+	moduleNameMapper: {
+		uuid: require.resolve( 'uuid' ),
+	},
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev": "webpack --watch",
     "build": "webpack",
     "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests"
+    "test:js": "jest --passWithNoTests",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -21,7 +23,6 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
-    "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@wordpress/element": "^5.15.0",
     "@wordpress/hooks": "^3.38.0",
     "@wordpress/i18n": "^4.38.0",
+    "@wordpress/icons": "^10.19.0",
     "@wordpress/keyboard-shortcuts": "^4.15.0",
     "@wordpress/plugins": "^6.10.0"
   },

--- a/search-replace-for-block-editor.php
+++ b/search-replace-for-block-editor.php
@@ -46,7 +46,7 @@ add_action( 'enqueue_block_editor_assets', function() {
 			'wp-plugins',
 			'wp-edit-post',
 		],
-		'1.3.0',
+		'1.4.0',
 		false,
 	);
 

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -2,11 +2,22 @@ import { __ } from '@wordpress/i18n';
 import { search } from '@wordpress/icons';
 import { dispatch, select } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { Modal, TextControl, ToggleControl, Button, Tooltip } from '@wordpress/components';
+import {
+	Modal,
+	TextControl,
+	ToggleControl,
+	Button,
+	Tooltip,
+} from '@wordpress/components';
 
 import '../styles/app.scss';
 
-import { getAllowedBlocks, getBlockEditorIframe, isCaseSensitive, inContainer } from './utils';
+import {
+	getAllowedBlocks,
+	getBlockEditorIframe,
+	isCaseSensitive,
+	isSelectionInModal,
+} from './utils';
 import { Shortcut } from './shortcut';
 
 /**
@@ -17,310 +28,335 @@ import { Shortcut } from './shortcut';
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} Search & Replace for Block Editor.
  */
 const SearchReplaceForBlockEditor = (): JSX.Element => {
-  const [ replacements, setReplacements ] = useState( 0 );
-  const [ isModalVisible, setIsModalVisible ] = useState( false );
-  const [ searchInput, setSearchInput ] = useState( '' );
-  const [ replaceInput, setReplaceInput ] = useState( '' );
-  const [ caseSensitive, setCaseSensitive ] = useState( false );
-  const [ context, setContext ] = useState( false );
+	const [ replacements, setReplacements ] = useState( 0 );
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const [ searchInput, setSearchInput ] = useState( '' );
+	const [ replaceInput, setReplaceInput ] = useState( '' );
+	const [ caseSensitive, setCaseSensitive ] = useState( false );
+	const [ context, setContext ] = useState( false );
 
-  /**
-   * Open Modal.
-   *
-   * @since 1.0.0
-   *
-   * @returns {void}
-   */
-  const openModal = (): void => {
-    setIsModalVisible( true );
-    setReplacements( 0 );
-  }
+	/**
+	 * Open Modal.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return {void}
+	 */
+	const openModal = (): void => {
+		setIsModalVisible( true );
+		setReplacements( 0 );
+	};
 
-  /**
-   * Close Modal.
-   *
-   * @since 1.0.0
-   *
-   * @returns {void}
-   */
-  const closeModal = (): void => {
-    setIsModalVisible( false );
-    setReplacements( 0 );
-  }
+	/**
+	 * Close Modal.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return {void}
+	 */
+	const closeModal = (): void => {
+		setIsModalVisible( false );
+		setReplacements( 0 );
+	};
 
-  /**
-   * On Selection.
-   *
-   * Populate the search field when the user selects
-   * a text range in the Block Editor.
-   *
-   * @since 1.2.0
-   *
-   * @returns {void}
-   */
-  const handleSelection = (): void => {
-    const selectedText: string = getBlockEditorIframe().getSelection().toString();
-    const modalSelector: string = '.search-replace-modal';
+	/**
+	 * On Selection.
+	 *
+	 * Populate the search field when the user selects
+	 * a text range in the Block Editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return {void}
+	 */
+	const handleSelection = (): void => {
+		const selectedText: string = getBlockEditorIframe()
+			.getSelection()
+			.toString();
 
-    if ( selectedText && ! inContainer( modalSelector ) ) {
-      setSearchInput( selectedText );
-    }
-  };
+		if ( selectedText && ! isSelectionInModal() ) {
+			setSearchInput( selectedText );
+		}
+	};
 
-  /**
-   * Listen for changes in Search Input & Case Sensitivity.
-   *
-   * By passing in a FALSY context to the replace callback, we only
-   * search for matched strings, we DO NOT replace matched strings.
-   *
-   * @since 1.3.0
-   *
-   * @returns {void}
-   */
-  useEffect( () => {
-    replace();
-  }, [ searchInput, caseSensitive ] );
+	/**
+	 * Listen for changes in Search Input & Case Sensitivity.
+	 *
+	 * By passing in a FALSY context to the replace callback, we only
+	 * search for matched strings, we DO NOT replace matched strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return {void}
+	 */
+	useEffect( () => {
+		replace();
+	}, [ searchInput, caseSensitive ] );
 
-  /**
-   * Handle case sensitive toggle feature
-   * to enable user perform case-sensitive search
-   * and replacements.
-   *
-   * @since 1.1.0
-   *
-   * @param {boolean} newValue
-   * @returns {void}
-   */
-  const handleCaseSensitive = ( newValue: boolean ): void => {
-    setCaseSensitive( newValue );
-  }
+	/**
+	 * Handle case sensitive toggle feature
+	 * to enable user perform case-sensitive search
+	 * and replacements.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param {boolean} newValue
+	 * @return {void}
+	 */
+	const handleCaseSensitive = ( newValue: boolean ): void => {
+		setCaseSensitive( newValue );
+	};
 
-  /**
-   * Handle the implementation for when the user
-   * clicks the 'Replace' button.
-   *
-   * @since 1.0.0
-   * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
-   *
-   * @param {boolean} context True (Replace), False (Search).
-   * @returns {void}
-   */
-  const replace = ( context: boolean = false ): void => {
-    setContext( context );
-    setReplacements( 0 );
+	/**
+	 * Handle the implementation for when the user
+	 * clicks the 'Replace' button.
+	 *
+	 * @since 1.0.0
+	 * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
+	 *
+	 * @param {boolean} context True (Replace), False (Search).
+	 * @return {void}
+	 */
+	const replace = ( context: boolean = false ): void => {
+		setContext( context );
+		setReplacements( 0 );
 
-    if ( ! searchInput ) {
-      return;
-    }
+		if ( ! searchInput ) {
+			return;
+		}
 
-    const pattern: RegExp = new RegExp(
-      `(?<!<[^>]*)${searchInput}(?<![^>]*<)`,
-      isCaseSensitive() || caseSensitive ? 'g' : 'gi'
-    );
+		const pattern: RegExp = new RegExp(
+			`(?<!<[^>]*)${ searchInput }(?<![^>]*<)`,
+			isCaseSensitive() || caseSensitive ? 'g' : 'gi'
+		);
 
-    select( 'core/block-editor' ).getBlocks().forEach( ( element ) => {
-      recursivelyReplace( element, pattern, replaceInput, context );
-    } );
-  };
+		select( 'core/block-editor' )
+			.getBlocks()
+			.forEach( ( element ) => {
+				recursivelyReplace( element, pattern, replaceInput, context );
+			} );
+	};
 
-  /**
-   * Recursively traverse and replace the text in the
-   * Block Editor with the user's text. Perform attribute update
-   * on a case by case basis based on mutating attribute.
-   *
-   * @since 1.0.0
-   * @since 1.0.1 Handle edge-cases for quote, pullquote & details block.
-   * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
-   *
-   * @param {Object} element Gutenberg editor block.
-   * @param {RegExp} pattern Search pattern.
-   * @param {string} text    Replace pattern.
-   * @param {boolean} context True (Replace), False (Search).
-   *
-   * @returns {void}
-   */
-  const recursivelyReplace = ( element, pattern, text, context ): void => {
-    if ( getAllowedBlocks().indexOf( element.name ) !== -1 ) {
-      const args = { element, pattern, text, context };
+	/**
+	 * Recursively traverse and replace the text in the
+	 * Block Editor with the user's text. Perform attribute update
+	 * on a case by case basis based on mutating attribute.
+	 *
+	 * @since 1.0.0
+	 * @since 1.0.1 Handle edge-cases for quote, pullquote & details block.
+	 * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
+	 *
+	 * @param {Object}  element Gutenberg editor block.
+	 * @param {RegExp}  pattern Search pattern.
+	 * @param {string}  text    Replace pattern.
+	 * @param {boolean} context True (Replace), False (Search).
+	 *
+	 * @return {void}
+	 */
+	const recursivelyReplace = ( element, pattern, text, context ): void => {
+		if ( getAllowedBlocks().indexOf( element.name ) !== -1 ) {
+			const args = { element, pattern, text, context };
 
-      switch( element.name ) {
-        case 'core/quote':
-        case 'core/pullquote':
-          replaceBlockAttribute( args, 'citation' );
-          break;
+			switch ( element.name ) {
+				case 'core/quote':
+				case 'core/pullquote':
+					replaceBlockAttribute( args, 'citation' );
+					break;
 
-        case 'core/details':
-          replaceBlockAttribute( args, 'summary' );
-          break;
+				case 'core/details':
+					replaceBlockAttribute( args, 'summary' );
+					break;
 
-        default:
-          replaceBlockAttribute( args, 'content' );
-          break;
-      }
-    }
+				default:
+					replaceBlockAttribute( args, 'content' );
+					break;
+			}
+		}
 
-    if ( element.innerBlocks.length ) {
-      element.innerBlocks.forEach( ( innerElement ) => {
-        recursivelyReplace( innerElement, pattern, text, context );
-      } );
-    }
-  }
+		if ( element.innerBlocks.length ) {
+			element.innerBlocks.forEach( ( innerElement ) => {
+				recursivelyReplace( innerElement, pattern, text, context );
+			} );
+		}
+	};
 
-  /**
-   * Do the actual job of replacing the string
-   * by dispatching the change using the block's clientId
-   * as reference.
-   *
-   * @since 1.0.1
-   *
-   * @param {Object} args      Args object containing element, pattern and text.
-   * @param {string} attribute The attribute to be mutated e.g. content.
-   *
-   * @returns {void}
-   */
-  const replaceBlockAttribute = ( args, attribute ): void => {
-    const { attributes, clientId } = args.element;
+	/**
+	 * Do the actual job of replacing the string
+	 * by dispatching the change using the block's clientId
+	 * as reference.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param {Object} args      Args object containing element, pattern and text.
+	 * @param {string} attribute The attribute to be mutated e.g. content.
+	 *
+	 * @return {void}
+	 */
+	const replaceBlockAttribute = ( args, attribute ): void => {
+		const { attributes, clientId } = args.element;
 
-    if ( undefined === attributes || undefined === attributes[attribute] ) {
-      return;
-    }
+		if (
+			undefined === attributes ||
+			undefined === attributes[ attribute ]
+		) {
+			return;
+		}
 
-    let oldString: string = attributes[attribute].text || attributes[attribute];
-    let newString: string = oldString.replace( args.pattern, () => {
-      setReplacements( ( items ) => items + 1 );
-      return args.text;
-    } );
+		const oldString: string =
+			attributes[ attribute ].text || attributes[ attribute ];
+		const newString: string = oldString.replace( args.pattern, () => {
+			setReplacements( ( items ) => items + 1 );
+			return args.text;
+		} );
 
-    if ( newString === oldString ) {
-      return;
-    }
+		if ( newString === oldString ) {
+			return;
+		}
 
-    const property = {};
-    property[attribute] = newString;
+		const property = {};
+		property[ attribute ] = newString;
 
-    if ( args.context ) {
-      ( dispatch( 'core/block-editor' ) as any )
-      .updateBlockAttributes( clientId, property );
-    }
+		if ( args.context ) {
+			( dispatch( 'core/block-editor' ) as any ).updateBlockAttributes(
+				clientId,
+				property
+			);
+		}
 
-    // Handle edge-case ('value') with Pullquotes.
-    if ( attributes.value ) {
-      if ( args.context ) {
-        ( dispatch('core/block-editor' ) as any )
-        .updateBlockAttributes( clientId, { value: newString } );
-      }
-      setReplacements( ( items ) => items + 1 );
-    }
-  }
+		// Handle edge-case ('value') with Pullquotes.
+		if ( attributes.value ) {
+			if ( args.context ) {
+				(
+					dispatch( 'core/block-editor' ) as any
+				 ).updateBlockAttributes( clientId, { value: newString } );
+			}
+			setReplacements( ( items ) => items + 1 );
+		}
+	};
 
-  /**
-   * Listen for Selection.
-   *
-   * Constantly listen for when the user selects a
-   * a text in the Block Editor.
-   *
-   * @since 1.2.0
-   *
-   * @returns {void}
-   */
-  useEffect( () => {
-    const editor = getBlockEditorIframe();
+	/**
+	 * Listen for Selection.
+	 *
+	 * Constantly listen for when the user selects a
+	 * a text in the Block Editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return {void}
+	 */
+	useEffect( () => {
+		const editor = getBlockEditorIframe();
 
-    editor.addEventListener(
-      'selectionchange', handleSelection
-    );
+		editor.addEventListener( 'selectionchange', handleSelection );
 
-    return () => {
-      editor.removeEventListener(
-        'selectionchange', handleSelection
-      );
-    };
-  }, [] );
+		return () => {
+			editor.removeEventListener( 'selectionchange', handleSelection );
+		};
+	}, [] );
 
-  return (
-    <>
-      <Shortcut onKeyDown={ openModal } />
-      <Tooltip text={ __( 'Search & Replace', 'search-replace-for-block-editor' ) }>
-        <Button
-          icon={ search }
-          label={ __( 'Search & Replace', 'search-replace-for-block-editor' ) }
-          onClick={ openModal }
-        />
-      </Tooltip>
-      {
-        isModalVisible && (
-          <Modal
-            title={ __( 'Search & Replace', 'search-replace-for-block-editor' ) }
-            onRequestClose={ closeModal }
-            className="search-replace-modal"
-          >
-            <div id="search-replace-modal__text-group">
-              <TextControl
-                type="text"
-                label={ __( 'Search' ) }
-                value={ searchInput }
-                onChange={ ( value ) => setSearchInput( value ) }
-                placeholder="Lorem ipsum..."
-                __nextHasNoMarginBottom
-              />
-              <TextControl
-                type="text"
-                label={ __( 'Replace' ) }
-                value={ replaceInput }
-                onChange={ ( value ) => setReplaceInput( value ) }
-                __nextHasNoMarginBottom
-              />
-            </div>
+	return (
+		<>
+			<Shortcut onKeyDown={ openModal } />
+			<Tooltip
+				text={ __(
+					'Search & Replace',
+					'search-replace-for-block-editor'
+				) }
+			>
+				<Button
+					icon={ search }
+					label={ __(
+						'Search & Replace',
+						'search-replace-for-block-editor'
+					) }
+					onClick={ openModal }
+				/>
+			</Tooltip>
+			{ isModalVisible && (
+				<Modal
+					title={ __(
+						'Search & Replace',
+						'search-replace-for-block-editor'
+					) }
+					onRequestClose={ closeModal }
+					className="search-replace-modal"
+				>
+					<div id="search-replace-modal__text-group">
+						<TextControl
+							type="text"
+							label={ __( 'Search' ) }
+							value={ searchInput }
+							onChange={ ( value ) => setSearchInput( value ) }
+							placeholder="Lorem ipsum..."
+							__nextHasNoMarginBottom
+						/>
+						<TextControl
+							type="text"
+							label={ __( 'Replace' ) }
+							value={ replaceInput }
+							onChange={ ( value ) => setReplaceInput( value ) }
+							__nextHasNoMarginBottom
+						/>
+					</div>
 
-            <div id="search-replace-modal__toggle">
-              <ToggleControl
-                label={ __( 'Match Case | Expression', 'search-replace-for-block-editor' ) }
-                checked={ caseSensitive }
-                onChange={ handleCaseSensitive }
-                __nextHasNoMarginBottom
-              />
-            </div>
+					<div id="search-replace-modal__toggle">
+						<ToggleControl
+							label={ __(
+								'Match Case | Expression',
+								'search-replace-for-block-editor'
+							) }
+							checked={ caseSensitive }
+							onChange={ handleCaseSensitive }
+							__nextHasNoMarginBottom
+						/>
+					</div>
 
-            {
-              replacements ? (
-                <div id="search-replace-modal__notification">
-                  <p>
-                    { context ? (
-                      <>
-                        <strong>{ replacements }</strong> { __( 'item(s) replaced successfully', 'search-replace-for-block-editor' ) }.
-                      </>
-                    ) : (
-                      <>
-                        <strong>{ replacements }</strong> { __( 'item(s) found', 'search-replace-for-block-editor' ) }.
-                      </>
-                    )}
-                  </p>
-                </div>
-              ) : ''
-            }
+					{ replacements ? (
+						<div id="search-replace-modal__notification">
+							<p>
+								{ context ? (
+									<>
+										<strong>{ replacements }</strong>{ ' ' }
+										{ __(
+											'item(s) replaced successfully',
+											'search-replace-for-block-editor'
+										) }
+										.
+									</>
+								) : (
+									<>
+										<strong>{ replacements }</strong>{ ' ' }
+										{ __(
+											'item(s) found',
+											'search-replace-for-block-editor'
+										) }
+										.
+									</>
+								) }
+							</p>
+						</div>
+					) : (
+						''
+					) }
 
-            <div id="search-replace-modal__button-group">
-              <Button
-                variant="primary"
-                onClick={ () => replace( true ) }
-              >
-                { __( 'Replace' ) }
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={ closeModal }
-              >
-                { __( 'Done' ) }
-              </Button>
-            </div>
-          </Modal>
-        )
-      }
-    </>
-  );
+					<div id="search-replace-modal__button-group">
+						<Button
+							variant="primary"
+							onClick={ () => replace( true ) }
+						>
+							{ __( 'Replace' ) }
+						</Button>
+						<Button variant="secondary" onClick={ closeModal }>
+							{ __( 'Done' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
 };
 
 export default SearchReplaceForBlockEditor;

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -64,23 +64,17 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	};
 
 	/**
-	 * On Selection.
+	 * Handle case sensitive toggle feature
+	 * to enable user perform case-sensitive search
+	 * and replacements.
 	 *
-	 * Populate the search field when the user selects
-	 * a text range in the Block Editor.
+	 * @since 1.1.0
 	 *
-	 * @since 1.2.0
-	 *
+	 * @param {boolean} newValue
 	 * @return {void}
 	 */
-	const handleSelection = (): void => {
-		const selectedText: string = getBlockEditorIframe()
-			.getSelection()
-			.toString();
-
-		if ( selectedText && ! isSelectionInModal() ) {
-			setSearchInput( selectedText );
-		}
+	const handleCaseSensitive = ( newValue: boolean ): void => {
+		setCaseSensitive( newValue );
 	};
 
 	/**
@@ -95,21 +89,8 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 */
 	useEffect( () => {
 		replace();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ searchInput, caseSensitive ] );
-
-	/**
-	 * Handle case sensitive toggle feature
-	 * to enable user perform case-sensitive search
-	 * and replacements.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param {boolean} newValue
-	 * @return {void}
-	 */
-	const handleCaseSensitive = ( newValue: boolean ): void => {
-		setCaseSensitive( newValue );
-	};
 
 	/**
 	 * Handle the implementation for when the user
@@ -136,8 +117,8 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 
 		select( 'core/block-editor' )
 			.getBlocks()
-			.forEach( ( element ) => {
-				recursivelyReplace( element, pattern, replaceInput, context );
+			.forEach( ( element: any ) => {
+				recursivelyReplace( element, pattern, replaceInput, status );
 			} );
 	};
 
@@ -157,11 +138,18 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 *
 	 * @return {void}
 	 */
-	const recursivelyReplace = ( element, pattern, text, context ): void => {
-		if ( getAllowedBlocks().indexOf( element.name ) !== -1 ) {
-			const args = { element, pattern, text, context };
+	const recursivelyReplace = (
+		element: any,
+		pattern: RegExp,
+		text: string,
+		status: boolean
+	): void => {
+		const { name, innerBlocks } = element;
 
-			switch ( element.name ) {
+		if ( getAllowedBlocks().indexOf( name ) !== -1 ) {
+			const args = { element, pattern, text, status };
+
+			switch ( name ) {
 				case 'core/quote':
 				case 'core/pullquote':
 					replaceBlockAttribute( args, 'citation' );
@@ -177,9 +165,9 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 			}
 		}
 
-		if ( element.innerBlocks.length ) {
-			element.innerBlocks.forEach( ( innerElement ) => {
-				recursivelyReplace( innerElement, pattern, text, context );
+		if ( innerBlocks.length ) {
+			innerBlocks.forEach( ( innerElement: any ) => {
+				recursivelyReplace( innerElement, pattern, text, status );
 			} );
 		}
 	};
@@ -196,8 +184,9 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 *
 	 * @return {void}
 	 */
-	const replaceBlockAttribute = ( args, attribute ): void => {
-		const { attributes, clientId } = args.element;
+	const replaceBlockAttribute = ( args: any, attribute: string ): void => {
+		const { pattern, text, element, status } = args;
+		const { attributes, clientId } = element;
 
 		if (
 			undefined === attributes ||

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -78,10 +78,8 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	};
 
 	/**
-	 * Listen for changes in Search Input & Case Sensitivity.
-	 *
-	 * By passing in a FALSY context to the replace callback, we only
-	 * search for matched strings, we DO NOT replace matched strings.
+	 * Listen for changes to input or case-sensitivity
+	 * and perform Searches only.
 	 *
 	 * @since 1.3.0
 	 *
@@ -97,9 +95,9 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 * clicks the 'Replace' button.
 	 *
 	 * @since 1.0.0
-	 * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
+	 * @since 1.3.0 Pass in context param (status) to determine if it is Search or Replace.
 	 *
-	 * @param {boolean} context True (Replace), False (Search).
+	 * @param {boolean} status The status of the context.
 	 * @return {void}
 	 */
 	const replace = ( context: boolean = false ): void => {
@@ -129,12 +127,12 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 *
 	 * @since 1.0.0
 	 * @since 1.0.1 Handle edge-cases for quote, pullquote & details block.
-	 * @since 1.3.0 Pass in context param to determine if it is Search or Replace.
+	 * @since 1.3.0 Pass in context param (status) to determine if it is Search or Replace.
 	 *
-	 * @param {Object}  element Gutenberg editor block.
+	 * @param {any}     element Gutenberg editor block.
 	 * @param {RegExp}  pattern Search pattern.
 	 * @param {string}  text    Replace pattern.
-	 * @param {boolean} context True (Replace), False (Search).
+	 * @param {boolean} status  True (Replace), False (Search).
 	 *
 	 * @return {void}
 	 */
@@ -179,7 +177,7 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 *
 	 * @since 1.0.1
 	 *
-	 * @param {Object} args      Args object containing element, pattern and text.
+	 * @param {any}    args      Args object containing element, pattern and text.
 	 * @param {string} attribute The attribute to be mutated e.g. content.
 	 *
 	 * @return {void}
@@ -240,20 +238,44 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	useEffect( () => {
 		const editor = getBlockEditorIframe();
 
+		if ( ! editor || editor === document ) {
+			return;
+		}
+
 		editor.addEventListener( 'selectionchange', handleSelection );
 
 		return () => {
 			editor.removeEventListener( 'selectionchange', handleSelection );
 		};
-	}, [] );
+	} );
+
+	/**
+	 * On Selection.
+	 *
+	 * Populate the search field when the user selects
+	 * a text range in the Block Editor.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return {void}
+	 */
+	const handleSelection = (): void => {
+		const selectedText: string = getBlockEditorIframe()
+			.getSelection()
+			.toString();
+
+		if ( selectedText && ! isSelectionInModal() ) {
+			setSearchInput( selectedText );
+		}
+	};
 
 	/**
 	 * Safe Shortcut.
 	 *
-	 * Check if the current WordPress version is greater than or equal to 6.4.0
+	 * Check if the current WP version is greater than or equal to 6.4.0
 	 * before rendering the Shortcut component.
 	 *
-	 * @since 1.3.1
+	 * @since 1.4.0
 	 * @return {JSX.Element|null} Shortcut.
 	 */
 	const SafeShortcut = (): JSX.Element | null =>

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -10,15 +10,16 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 
-import '../styles/app.scss';
-
+import { Shortcut } from './shortcut';
 import {
 	getAllowedBlocks,
 	getBlockEditorIframe,
 	isCaseSensitive,
 	isSelectionInModal,
+	isWpVersion,
 } from './utils';
-import { Shortcut } from './shortcut';
+
+import '../styles/app.scss';
 
 /**
  * Search & Replace for Block Editor.
@@ -257,9 +258,21 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 		};
 	}, [] );
 
+	/**
+	 * Safe Shortcut.
+	 *
+	 * Check if the current WordPress version is greater than or equal to 6.4.0
+	 * before rendering the Shortcut component.
+	 *
+	 * @since 1.3.1
+	 * @return {JSX.Element|null} Shortcut.
+	 */
+	const SafeShortcut = (): JSX.Element | null =>
+		isWpVersion( '6.4.0' ) ? <Shortcut onKeyDown={ openModal } /> : null;
+
 	return (
 		<>
-			<Shortcut onKeyDown={ openModal } />
+			<SafeShortcut />
 			<Tooltip
 				text={ __(
 					'Search & Replace',

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -100,8 +100,8 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 * @param {boolean} status The status of the context.
 	 * @return {void}
 	 */
-	const replace = ( context: boolean = false ): void => {
-		setContext( context );
+	const replace = ( status: boolean = false ): void => {
+		setContext( status );
 		setReplacements( 0 );
 
 		if ( ! searchInput ) {
@@ -195,9 +195,10 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 
 		const oldString: string =
 			attributes[ attribute ].text || attributes[ attribute ];
-		const newString: string = oldString.replace( args.pattern, () => {
+
+		const newString: string = oldString.replace( pattern, () => {
 			setReplacements( ( items ) => items + 1 );
-			return args.text;
+			return text;
 		} );
 
 		if ( newString === oldString ) {
@@ -207,7 +208,7 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 		const property = {};
 		property[ attribute ] = newString;
 
-		if ( args.context ) {
+		if ( status ) {
 			( dispatch( 'core/block-editor' ) as any ).updateBlockAttributes(
 				clientId,
 				property
@@ -216,7 +217,7 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 
 		// Handle edge-case ('value') with Pullquotes.
 		if ( attributes.value ) {
-			if ( args.context ) {
+			if ( status ) {
 				(
 					dispatch( 'core/block-editor' ) as any
 				 ).updateBlockAttributes( clientId, { value: newString } );

--- a/src/core/shortcut.tsx
+++ b/src/core/shortcut.tsx
@@ -12,31 +12,31 @@ import { getShortcut, isWpVersion } from './utils';
  *
  * @since 1.0.1
  *
- * @param {Object}   Props.
- * @param {function} OpenModal Function.
+ * @param {Object}   props           - The properties object.
+ * @param {Function} props.onKeyDown - The function to call when the shortcut is triggered.
  *
- * @returns {JSX.Element|null}
+ * @return {JSX.Element|null} Shortcut.
  */
 export const Shortcut = ( { onKeyDown } ): JSX.Element | null => {
-  if ( ! isWpVersion( '6.4.0' ) ) {
-    return null;
-  }
+	const dispatch = useDispatch();
 
-  const dispatch = useDispatch();
+	if ( ! isWpVersion( '6.4.0' ) ) {
+		return null;
+	}
 
-  dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {
-    name: 'search-replace-for-block-editor/search-replace',
-    keyCombination: getShortcut(),
-    category: 'global',
-    description: 'Search & Replace',
-  } );
+	dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {
+		name: 'search-replace-for-block-editor/search-replace',
+		keyCombination: getShortcut(),
+		category: 'global',
+		description: 'Search & Replace',
+	} );
 
-  useShortcut(
-    'search-replace-for-block-editor/search-replace',
-    useCallback( () => {
-      onKeyDown();
-    }, [] )
-  );
+	useShortcut(
+		'search-replace-for-block-editor/search-replace',
+		useCallback( () => {
+			onKeyDown();
+		} )
+	);
 
-  return null;
+	return null;
 };

--- a/src/core/shortcut.tsx
+++ b/src/core/shortcut.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
-import { getShortcut, isWpVersion } from './utils';
+import { getShortcut } from './utils';
 
 /**
  * Shortcut for Block Editor.
@@ -20,10 +20,6 @@ import { getShortcut, isWpVersion } from './utils';
 export const Shortcut = ( { onKeyDown } ): JSX.Element | null => {
 	const dispatch = useDispatch();
 
-	if ( ! isWpVersion( '6.4.0' ) ) {
-		return null;
-	}
-
 	dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {
 		name: 'search-replace-for-block-editor/search-replace',
 		keyCombination: getShortcut(),
@@ -35,7 +31,8 @@ export const Shortcut = ( { onKeyDown } ): JSX.Element | null => {
 		'search-replace-for-block-editor/search-replace',
 		useCallback( () => {
 			onKeyDown();
-		} )
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] )
 	);
 
 	return null;

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -9,22 +9,25 @@ import { getBlockTypes } from '@wordpress/blocks';
  *
  * @since 1.0.0
  *
- * @returns {string[]}
+ * @return {string[]} List of Allowed Blocks.
  */
 export const getAllowedBlocks = (): string[] => {
-  /**
-   * Allow Text Blocks.
-   *
-   * Filter and allow only these Specific blocks
-   * for the Search & Replace.
-   *
-   * @since 1.0.0
-   *
-   * @param {string[]} blocks List of Blocks.
-   * @returns {string[]}
-   */
-  return applyFilters( 'search-replace-for-block-editor.allowedBlocks', getTextBlocks() ) as string[];
-}
+	/**
+	 * Allow Text Blocks.
+	 *
+	 * Filter and allow only these Specific blocks
+	 * for the Search & Replace.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param {string[]} blocks List of Blocks.
+	 * @return {string[]}
+	 */
+	return applyFilters(
+		'search-replace-for-block-editor.allowedBlocks',
+		getTextBlocks()
+	) as string[];
+};
 
 /**
  * Get Text Blocks.
@@ -34,15 +37,16 @@ export const getAllowedBlocks = (): string[] => {
  *
  * @since 1.0.0
  *
- * @returns {string[]}
+ * @return {string[]} List of Text Blocks.
  */
-export const getTextBlocks = (): string[] => getBlockTypes()
-  .filter( ( block ) => {
-    return !!(block?.category === 'text');
-  } )
-  .map( ( block ) => {
-    return block?.name;
-  } );
+export const getTextBlocks = (): string[] =>
+	getBlockTypes()
+		.filter( ( block ) => {
+			return !! ( block?.category === 'text' );
+		} )
+		.map( ( block ) => {
+			return block?.name;
+		} );
 
 /**
  * Get ShortCut.
@@ -52,37 +56,40 @@ export const getTextBlocks = (): string[] => getBlockTypes()
  *
  * @since 1.0.1
  *
- * @returns {Object}
+ * @return {Object} Shortcut Option.
  */
 export const getShortcut = () => {
-  const options = {
-    CMD: {
-      modifier: 'primary',
-      character: 'f',
-    },
-    SHIFT: {
-      modifier: 'primaryShift',
-      character: 'f',
-    },
-    ALT: {
-      modifier: 'primaryAlt',
-      character: 'f',
-    },
-  }
+	const options = {
+		CMD: {
+			modifier: 'primary',
+			character: 'f',
+		},
+		SHIFT: {
+			modifier: 'primaryShift',
+			character: 'f',
+		},
+		ALT: {
+			modifier: 'primaryAlt',
+			character: 'f',
+		},
+	};
 
-  /**
-   * Filter Keyboard Shortcut.
-   *
-   * By default the passed option would be SHIFT which
-   * represents `CMD + SHIFT + F`.
-   *
-   * @since 1.0.1
-   *
-   * @param {Object} Shortcut Option.
-   * @returns {Object}
-   */
-  return applyFilters( 'search-replace-for-block-editor.keyboardShortcut', options.SHIFT );
-}
+	/**
+	 * Filter Keyboard Shortcut.
+	 *
+	 * By default the passed option would be SHIFT which
+	 * represents `CMD + SHIFT + F`.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param {Object} Shortcut Option.
+	 * @return {Object}
+	 */
+	return applyFilters(
+		'search-replace-for-block-editor.keyboardShortcut',
+		options.SHIFT
+	);
+};
 
 /**
  * Determine if a Search & Replace activity is case-sensitive
@@ -90,21 +97,24 @@ export const getShortcut = () => {
  *
  * @since 1.0.2
  *
- * @returns {boolean}
+ * @return {boolean} Is Case Sensitive.
  */
 export const isCaseSensitive = (): boolean => {
-  /**
-   * Filter Case Sensitivity.
-   *
-   * By default this would be a falsy value.
-   *
-   * @since 1.0.2
-   *
-   * @param {boolean} Case Sensitivity.
-   * @returns {boolean}
-   */
-  return applyFilters( 'search-replace-for-block-editor.caseSensitive', false ) as boolean;
-}
+	/**
+	 * Filter Case Sensitivity.
+	 *
+	 * By default this would be a falsy value.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param {boolean} Case Sensitivity.
+	 * @return {boolean}
+	 */
+	return applyFilters(
+		'search-replace-for-block-editor.caseSensitive',
+		false
+	) as boolean;
+};
 
 /**
  * Get Editor Root.
@@ -114,32 +124,34 @@ export const isCaseSensitive = (): boolean => {
  *
  * @since 1.2.0
  *
- * @returns Promise<HTMLElement | Error>
+ * @return Promise<HTMLElement | Error>
  */
-export const getEditorRoot = (): Promise<HTMLElement | Error> => {
-  let elapsedTime: number = 0;
-  const interval: number = 100;
+export const getEditorRoot = (): Promise< HTMLElement | Error > => {
+	let elapsedTime: number = 0;
+	const interval: number = 100;
 
-  const selector: string = isWpVersion( '6.6.0' )
-    ? '.editor-header__toolbar'
-    : '.edit-post-header__toolbar';
+	const selector: string = isWpVersion( '6.6.0' )
+		? '.editor-header__toolbar'
+		: '.edit-post-header__toolbar';
 
-  return new Promise( ( resolve, reject ) => {
-    const intervalId = setInterval( () => {
-      elapsedTime += interval;
-      const root = document.querySelector(selector) as HTMLElement | null;
+	return new Promise( ( resolve, reject ) => {
+		const intervalId = setInterval( () => {
+			elapsedTime += interval;
+			const root = document.querySelector(
+				selector
+			) as HTMLElement | null;
 
-      if ( root ) {
-        clearInterval(intervalId);
-        resolve( root );
-      }
+			if ( root ) {
+				clearInterval( intervalId );
+				resolve( root );
+			}
 
-      if ( elapsedTime > ( 600 * interval ) ) {
-        clearInterval( intervalId );
-        reject( new Error( 'Unable to get Editor root container...' ) );
-      }
-    }, interval);
-  } );
+			if ( elapsedTime > 600 * interval ) {
+				clearInterval( intervalId );
+				reject( new Error( 'Unable to get Editor root container...' ) );
+			}
+		}, interval );
+	} );
 };
 
 /**
@@ -151,14 +163,14 @@ export const getEditorRoot = (): Promise<HTMLElement | Error> => {
  * @since 1.2.0
  *
  * @param {HTMLElement} parent - The Parent DOM element.
- * @returns {HTMLDivElement}
+ * @return {HTMLDivElement} HTML Div Element
  */
 export const getAppRoot = ( parent: HTMLElement ): HTMLDivElement => {
-  const container: HTMLDivElement = document.createElement( 'div' );
-  container.id = 'search-replace';
-  parent.appendChild( container );
+	const container: HTMLDivElement = document.createElement( 'div' );
+	container.id = 'search-replace';
+	parent.appendChild( container );
 
-  return container;
+	return container;
 };
 
 /**
@@ -169,37 +181,45 @@ export const getAppRoot = ( parent: HTMLElement ): HTMLDivElement => {
  *
  * @since 1.2.1
  *
- * @returns {Document}
+ * @return {Document} Document Object.
  */
 export const getBlockEditorIframe = (): Document => {
-  const editor = document.querySelector( 'iframe[name="editor-canvas"]' );
+	const editor = document.querySelector( 'iframe[name="editor-canvas"]' );
 
-  return editor && editor instanceof HTMLIFrameElement
-    ? editor.contentDocument || editor.contentWindow?.document
-    : document;
-}
+	return editor && editor instanceof HTMLIFrameElement
+		? editor.contentDocument || editor.contentWindow?.document
+		: document;
+};
 
 /**
- * Check if the selection is made inside a Container,
- * for e.g. the `search-replace-modal`.
+ * Check if the selection is made inside the,
+ * `search-replace-modal`.
  *
  * @since 1.2.1
  *
- * @param {string} selector Target selector.
- * @returns {boolean}
+ * @return {boolean} Is Selection in Modal.
  */
-export const inContainer = ( selector: string ): boolean => {
-  const selection = window.getSelection() as Selection | null;
-  const targetDiv = document.querySelector( selector ) as HTMLElement | null;
+export const isSelectionInModal = (): boolean => {
+	const modalSelector: string = '.search-replace-modal';
 
-  if ( ! selection?.rangeCount || ! targetDiv ) {
-    return false;
-  }
+	// eslint-disable-next-line @wordpress/no-global-get-selection
+	const selection = window.getSelection() as Selection | null;
 
-  const range: Range = selection.getRangeAt( 0 );
+	const targetDiv = document.querySelector(
+		modalSelector
+	) as HTMLElement | null;
 
-  return targetDiv.contains( range.startContainer ) && targetDiv.contains( range.endContainer );
-}
+	if ( ! selection?.rangeCount || ! targetDiv ) {
+		return false;
+	}
+
+	const range: Range = selection.getRangeAt( 0 );
+
+	return (
+		targetDiv.contains( range.startContainer ) &&
+		targetDiv.contains( range.endContainer )
+	);
+};
 
 /**
  * Check if it's up to WP version.
@@ -207,21 +227,21 @@ export const inContainer = ( selector: string ): boolean => {
  * @since 1.2.2
  *
  * @param {string} version WP Version.
- * @returns {boolean}
+ * @return {boolean} Is WP Version.
  */
 export const isWpVersion = ( version: string ): boolean => {
-  const { wpVersion } = srfbe as { wpVersion: string };
+	const { wpVersion } = srfbe as { wpVersion: string };
 
-  const argVersion: number = getNumberToBase10(
-    version.split( '.' ).map( Number )
-  );
+	const argVersion: number = getNumberToBase10(
+		version.split( '.' ).map( Number )
+	);
 
-  const sysVersion: number = getNumberToBase10(
-    wpVersion.split( '.' ).map( Number )
-  );
+	const sysVersion: number = getNumberToBase10(
+		wpVersion.split( '.' ).map( Number )
+	);
 
-  return ! ( sysVersion < argVersion );
-}
+	return ! ( sysVersion < argVersion );
+};
 
 /**
  * Given an array of numbers, get the Radix
@@ -231,12 +251,15 @@ export const isWpVersion = ( version: string ): boolean => {
  * @since 1.2.2
  *
  * @param {number[]} values Array of positive numbers.
- * @returns {number}
+ * @return {number} Get Radix.
  */
 export const getNumberToBase10 = ( values: number[] ): number => {
-  const radix: number = values.reduce( ( sum: number, value: number, index: number ) => {
-    return sum + ( value * Math.pow(10, ( (values.length - 1) - index) ) );
-  }, 0 );
+	const radix: number = values.reduce(
+		( sum: number, value: number, index: number ) => {
+			return sum + value * Math.pow( 10, values.length - 1 - index );
+		},
+		0
+	);
 
-  return radix;
-}
+	return radix;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable no-console */
+/* eslint-disable react/no-deprecated */
+/* eslint-disable import/no-extraneous-dependencies */
+
 import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,17 +2,17 @@ import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
 import SearchReplaceForBlockEditor from './core/app';
-import { getAppRoot, getEditorRoot, isWpVersion } from './core/utils'
+import { getAppRoot, getEditorRoot, isWpVersion } from './core/utils';
 
-(async () => {
-  try {
-    const app = getAppRoot(await getEditorRoot() as HTMLElement);
-    if (!isWpVersion('6.2.0')) {
-      ReactDOM.render(<SearchReplaceForBlockEditor />, app);
-    } else {
-      createRoot(app).render(<SearchReplaceForBlockEditor />);
-    }
-  } catch (e) {
-    console.error(e);
-  }
-})();
+( async () => {
+	try {
+		const app = getAppRoot( ( await getEditorRoot() ) as HTMLElement );
+		if ( ! isWpVersion( '6.2.0' ) ) {
+			ReactDOM.render( <SearchReplaceForBlockEditor />, app );
+		} else {
+			createRoot( app ).render( <SearchReplaceForBlockEditor /> );
+		}
+	} catch ( e ) {
+		console.error( e );
+	}
+} )();

--- a/tests/filters.test.tsx
+++ b/tests/filters.test.tsx
@@ -1,102 +1,110 @@
-describe('search-replace-for-block-editor.allowedBlocks', () => {
-  it('passes and returns Blocks with filters applied', () => {
-    jest.doMock('@wordpress/hooks', () => ({
-      applyFilters: jest.fn((hook: string, arg: string[]) => {
-        return [...arg, 'core/table'];
-      }),
-    }));
+describe( 'search-replace-for-block-editor.allowedBlocks', () => {
+	it( 'passes and returns Blocks with filters applied', () => {
+		jest.doMock( '@wordpress/hooks', () => ( {
+			applyFilters: jest.fn( ( hook: string, arg: string[] ) => {
+				return [ ...arg, 'core/table' ];
+			} ),
+		} ) );
 
-    jest.doMock('../src/core/utils', () => ({
-      getTextBlocks: jest.fn(() => {
-        return ['core/paragraph', 'core/pullquote', 'core/preformatted'];
-      }),
-      getAllowedBlocks: jest.fn(() => {
-        const { applyFilters } = require('@wordpress/hooks');
-        const { getTextBlocks } = require('../src/core/utils');
-        return applyFilters('search-replace-for-block-editor.allowedBlocks', getTextBlocks());
-      }),
-    }));
+		jest.doMock( '../src/core/utils', () => ( {
+			getTextBlocks: jest.fn( () => {
+				return [
+					'core/paragraph',
+					'core/pullquote',
+					'core/preformatted',
+				];
+			} ),
+			getAllowedBlocks: jest.fn( () => {
+				const { applyFilters } = require( '@wordpress/hooks' );
+				const { getTextBlocks } = require( '../src/core/utils' );
+				return applyFilters(
+					'search-replace-for-block-editor.allowedBlocks',
+					getTextBlocks()
+				);
+			} ),
+		} ) );
 
-    const { getAllowedBlocks } = require('../src/core/utils');
-    const blocks = getAllowedBlocks();
-    expect(blocks).toEqual(
-      [
-        'core/paragraph',
-        'core/pullquote',
-        'core/preformatted',
-        'core/table',
-      ]
-    );
-    expect(blocks.length).toEqual(4);
-  });
+		const { getAllowedBlocks } = require( '../src/core/utils' );
+		const blocks = getAllowedBlocks();
+		expect( blocks ).toEqual( [
+			'core/paragraph',
+			'core/pullquote',
+			'core/preformatted',
+			'core/table',
+		] );
+		expect( blocks.length ).toEqual( 4 );
+	} );
 
-  it('passes and returns empty array of ', () => {
-    jest.doMock('@wordpress/hooks', () => ({
-      applyFilters: jest.fn((hook: string, arg: string[]) => {
-        return [];
-      }),
-    }));
+	it( 'passes and returns empty array of ', () => {
+		jest.doMock( '@wordpress/hooks', () => ( {
+			applyFilters: jest.fn( ( hook: string, arg: string[] ) => {
+				return [];
+			} ),
+		} ) );
 
-    jest.doMock('../src/core/utils', () => ({
-      getTextBlocks: jest.fn(() => {
-        return ['core/paragraph', 'core/pullquote', 'core/preformatted'];
-      }),
-      getAllowedBlocks: jest.fn(() => {
-        const { applyFilters } = require('@wordpress/hooks');
-        const { getTextBlocks } = require('../src/core/utils');
-        return applyFilters('search-replace-for-block-editor.allowedBlocks', getTextBlocks());
-      }),
-    }));
+		jest.doMock( '../src/core/utils', () => ( {
+			getTextBlocks: jest.fn( () => {
+				return [
+					'core/paragraph',
+					'core/pullquote',
+					'core/preformatted',
+				];
+			} ),
+			getAllowedBlocks: jest.fn( () => {
+				const { applyFilters } = require( '@wordpress/hooks' );
+				const { getTextBlocks } = require( '../src/core/utils' );
+				return applyFilters(
+					'search-replace-for-block-editor.allowedBlocks',
+					getTextBlocks()
+				);
+			} ),
+		} ) );
 
-    const { getAllowedBlocks } = require('../src/core/utils');
-    const blocks = getAllowedBlocks();
-    expect(blocks).toEqual([]);
-    expect(blocks.length).toEqual(0);
-  });
+		const { getAllowedBlocks } = require( '../src/core/utils' );
+		const blocks = getAllowedBlocks();
+		expect( blocks ).toEqual( [] );
+		expect( blocks.length ).toEqual( 0 );
+	} );
 
-  afterEach(() => {
-    jest.unmock('@wordpress/hooks');
-    jest.unmock('../src/core/utils');
-    jest.resetModules();
-  });
-});
+	afterEach( () => {
+		jest.unmock( '@wordpress/hooks' );
+		jest.unmock( '../src/core/utils' );
+		jest.resetModules();
+	} );
+} );
 
-describe('search-replace-for-block-editor.keyboardShortcut', () => {
-  it('passes and returns the default keyboard shortcut', () => {
-    jest.doMock('@wordpress/hooks', () => ({
-      applyFilters: jest.fn((hook: string, arg: object) => arg),
-    }));
+describe( 'search-replace-for-block-editor.keyboardShortcut', () => {
+	it( 'passes and returns the default keyboard shortcut', () => {
+		jest.doMock( '@wordpress/hooks', () => ( {
+			applyFilters: jest.fn( ( hook: string, arg: object ) => arg ),
+		} ) );
 
-    const { getShortcut } = require('../src/core/utils');
-    const shortcut = getShortcut();
-    expect(shortcut).toStrictEqual(
-      {
-        character: 'f',
-        modifier: 'primaryShift'
-      }
-    );
-  });
+		const { getShortcut } = require( '../src/core/utils' );
+		const shortcut = getShortcut();
+		expect( shortcut ).toStrictEqual( {
+			character: 'f',
+			modifier: 'primaryShift',
+		} );
+	} );
 
-  it('passes and returns a custom keyboard shortcut', () => {
-    jest.doMock('@wordpress/hooks', () => ({
-      applyFilters: jest.fn((hook: string, arg: object) => {
-        return { ...arg, character: 'j' };
-      }),
-    }));
+	it( 'passes and returns a custom keyboard shortcut', () => {
+		jest.doMock( '@wordpress/hooks', () => ( {
+			applyFilters: jest.fn( ( hook: string, arg: object ) => {
+				return { ...arg, character: 'j' };
+			} ),
+		} ) );
 
-    const { getShortcut } = require('../src/core/utils');
-    const shortcut = getShortcut();
-    expect(shortcut).toStrictEqual(
-      {
-        character: 'j',
-        modifier: 'primaryShift'
-      }
-    );
-  });
+		const { getShortcut } = require( '../src/core/utils' );
+		const shortcut = getShortcut();
+		expect( shortcut ).toStrictEqual( {
+			character: 'j',
+			modifier: 'primaryShift',
+		} );
+	} );
 
-  afterEach(() => {
-    jest.unmock('@wordpress/hooks');
-    jest.unmock('../src/core/utils');
-    jest.resetModules();
-  });
-});
+	afterEach( () => {
+		jest.unmock( '@wordpress/hooks' );
+		jest.unmock( '../src/core/utils' );
+		jest.resetModules();
+	} );
+} );

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,34 +1,36 @@
 import { getTextBlocks } from '../src/core/utils';
 
-jest.mock('@wordpress/blocks', () => ({
-  getBlockTypes: jest.fn(() => {
-    return [
-      1,
-      'string',
-      true,
-      null,
-      undefined,
-      [],
-      {},
-      { name: 'core/paragraph' },
-      { category: 'text', name: 'core/paragraph' },
-      { category: 'image', name: 'core/image' },
-      { category: 'text', name: 'core/pullquote' },
-      { category: 'text', name: 'core/preformatted' },
-    ]
-  }),
-}));
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockTypes: jest.fn( () => {
+		return [
+			1,
+			'string',
+			true,
+			null,
+			undefined,
+			[],
+			{},
+			{ name: 'core/paragraph' },
+			{ category: 'text', name: 'core/paragraph' },
+			{ category: 'image', name: 'core/image' },
+			{ category: 'text', name: 'core/pullquote' },
+			{ category: 'text', name: 'core/preformatted' },
+		];
+	} ),
+} ) );
 
-describe('getTextBlocks', () => {
-  it('passes and returns Blocks in the `text` category', () => {
-    const blocks = getTextBlocks();
-    expect(blocks).toEqual(
-      ['core/paragraph', 'core/pullquote', 'core/preformatted']
-    );
-  });
+describe( 'getTextBlocks', () => {
+	it( 'passes and returns Blocks in the `text` category', () => {
+		const blocks = getTextBlocks();
+		expect( blocks ).toEqual( [
+			'core/paragraph',
+			'core/pullquote',
+			'core/preformatted',
+		] );
+	} );
 
-  it('passes and returns Length of Blocks', () => {
-    const blocks = getTextBlocks();
-    expect(blocks.length).toBe(3);
-  });
-})
+	it( 'passes and returns Length of Blocks', () => {
+		const blocks = getTextBlocks();
+		expect( blocks.length ).toBe( 3 );
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,64 +1,68 @@
-const path = require('path');
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-  ...defaultConfig,
+	...defaultConfig,
 
-  entry: {
-    app: './src/index.tsx',
-  },
+	entry: {
+		app: './src/index.tsx',
+	},
 
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
-  },
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: '[name].js',
+	},
 
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
+	resolve: {
+		extensions: [ '.tsx', '.ts', '.js' ],
+	},
 
-  module: {
-    rules: [
-      {
-        test: /\.ts(x)?$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            configFile: 'tsconfig.json',
-            transpileOnly: true
-          }
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-          },
-        },
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'images/',
-            },
-          },
-        ],
-      },
-      {
-        test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-    ],
-  },
+	module: {
+		rules: [
+			{
+				test: /\.ts(x)?$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.json',
+						transpileOnly: true,
+					},
+				},
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-env',
+							'@babel/preset-react',
+							'@babel/preset-typescript',
+						],
+					},
+				},
+			},
+			{
+				test: /\.(png|jpg|jpeg|gif|svg)$/,
+				use: [
+					{
+						loader: 'file-loader',
+						options: {
+							name: '[name].[ext]',
+							outputPath: 'images/',
+						},
+					},
+				],
+			},
+			{
+				test: /\.scss$/,
+				use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+			},
+		],
+	},
 
-  devtool: 'source-map',
-  mode: 'production'
+	devtool: 'source-map',
+	mode: 'production',
 };


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/43).

## Description / Background Context

There is a need to enforce WP style linting across the codebase to ensure consistency among PRs. Once done, Contributors should be able to lint and perform fixes easily like so:

```js
yarn lint:js
yarn lint:fix
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn dev`.
3. Now run `yarn lint:fix` to correctly lint your JS files.
4. All other features should work correctly as before.