### PR TITLE
Chore: Update unit test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0
 * Feat: Add search icon to Toolbar.
 * Chore: Enforce WP linting across plugin.
+* Test: Improve unit tests cases.
 * Tested up to WP 6.7.2.
 
 ## 1.3.0

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"dev": "webpack --watch",
 		"build": "webpack",
 		"test": "npm-run-all --parallel test:*",
-		"test:js": "jest --passWithNoTests",
+		"test:js": "jest --passWithNoTests --verbose",
 		"lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
 		"lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
 		"format": "eslint . --ext .js,.jsx,.ts,.tsx --fix"

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 = 1.4.0 =
 * Feat: Add search icon to Toolbar.
 * Chore: Enforce WP linting across plugin.
+* Test: Improve unit tests cases.
 * Tested up to WP 6.7.2.
 
 = 1.3.0 =

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -61,7 +61,7 @@ export const getTextBlocks = (): string[] => {
  *
  * @return {Object} Shortcut Option.
  */
-export const getShortcut = () => {
+export const getShortcut = (): { modifier: string; character: string } => {
 	const options = {
 		CMD: {
 			modifier: 'primary',
@@ -91,7 +91,7 @@ export const getShortcut = () => {
 	return applyFilters(
 		'search-replace-for-block-editor.keyboardShortcut',
 		options.SHIFT
-	);
+	) as { modifier: string; character: string };
 };
 
 /**

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -233,17 +233,24 @@ export const isSelectionInModal = (): boolean => {
  * @return {boolean} Is WP Version.
  */
 export const isWpVersion = ( version: string ): boolean => {
-	const { wpVersion } = srfbe as { wpVersion: string };
+	if ( typeof version !== 'string' ) {
+		return false;
+	}
 
-	const argVersion: number = getNumberToBase10(
-		version.split( '.' ).map( Number )
-	);
+	const argVersion = version;
+	const { wpVersion: sysVersion } = srfbe as { wpVersion: string };
 
-	const sysVersion: number = getNumberToBase10(
-		wpVersion.split( '.' ).map( Number )
-	);
+	const argVersionArray = argVersion.split( '.' ).map( Number );
+	const sysVersionArray = sysVersion.split( '.' ).map( Number );
 
-	return ! ( sysVersion < argVersion );
+	if ( argVersionArray?.length !== 3 || sysVersionArray?.length !== 3 ) {
+		return false;
+	}
+
+	const argVersionRadix: number = getNumberToBase10( argVersionArray );
+	const sysVersionRadix: number = getNumberToBase10( sysVersionArray );
+
+	return ! ( sysVersionRadix < argVersionRadix );
 };
 
 /**
@@ -257,6 +264,16 @@ export const isWpVersion = ( version: string ): boolean => {
  * @return {number} Get Radix.
  */
 export const getNumberToBase10 = ( values: number[] ): number => {
+	if ( ! Array.isArray( values ) ) {
+		return 0;
+	}
+
+	for ( let i = 0; i < values.length; i++ ) {
+		if ( ! Number.isInteger( values[ i ] ) ) {
+			return 0;
+		}
+	}
+
 	const radix: number = values.reduce(
 		( sum: number, value: number, index: number ) => {
 			return sum + value * Math.pow( 10, values.length - 1 - index );

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,27 +1,78 @@
-import { getTextBlocks } from '../src/core/utils';
-
-jest.mock( '@wordpress/blocks', () => ( {
-	getBlockTypes: jest.fn( () => {
-		return [
-			1,
-			'string',
-			true,
-			null,
-			undefined,
-			[],
-			{},
-			{ name: 'core/paragraph' },
-			{ category: 'text', name: 'core/paragraph' },
-			{ category: 'image', name: 'core/image' },
-			{ category: 'text', name: 'core/pullquote' },
-			{ category: 'text', name: 'core/preformatted' },
-		];
-	} ),
-} ) );
+interface Window {
+	srfbe: {
+		wpVersion: string;
+	};
+}
 
 describe( 'getTextBlocks', () => {
-	it( 'passes and returns Blocks in the `text` category', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
+
+	it( 'getAllowedBlocks passes and returns default Text Blocks', () => {
+		const { getAllowedBlocks } = require( '../src/core/utils' );
+
+		const blocks = getAllowedBlocks();
+
+		expect( blocks ).toEqual( [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/list-item',
+			'core/quote',
+			'core/code',
+			'core/details',
+			'core/missing',
+			'core/preformatted',
+			'core/pullquote',
+			'core/table',
+			'core/verse',
+			'core/footnotes',
+			'core/freeform',
+		] );
+		expect( blocks.length ).toBe( 14 );
+	} );
+
+	it( 'getAllowedBlocks returns limited number of Text Blocks', () => {
+		jest.doMock( '@wordpress/blocks', () => ( {
+			getBlockTypes: jest.fn( () => [
+				{ name: 'core/paragraph' },
+				{ category: 'text', name: 'core/paragraph' },
+				{ category: 'image', name: 'core/image' },
+				{ category: 'text', name: 'core/pullquote' },
+				{ category: 'text', name: 'core/preformatted' },
+			] ),
+		} ) );
+
+		const { getAllowedBlocks } = require( '../src/core/utils' );
+
+		const blocks = getAllowedBlocks();
+
+		expect( blocks.length ).toBe( 3 );
+	} );
+
+	it( 'getTextBlocks passes and returns Blocks in the `text` category', () => {
+		jest.doMock( '@wordpress/blocks', () => ( {
+			getBlockTypes: jest.fn( () => [
+				1,
+				'string',
+				true,
+				null,
+				undefined,
+				[],
+				{},
+				{ name: 'core/paragraph' },
+				{ category: 'text', name: 'core/paragraph' },
+				{ category: 'image', name: 'core/image' },
+				{ category: 'text', name: 'core/pullquote' },
+				{ category: 'text', name: 'core/preformatted' },
+			] ),
+		} ) );
+
+		const { getTextBlocks } = require( '../src/core/utils' );
+
 		const blocks = getTextBlocks();
+
 		expect( blocks ).toEqual( [
 			'core/paragraph',
 			'core/pullquote',
@@ -29,8 +80,220 @@ describe( 'getTextBlocks', () => {
 		] );
 	} );
 
-	it( 'passes and returns Length of Blocks', () => {
+	it( 'getTextBlocks passes and returns Length of Blocks', () => {
+		jest.doMock( '@wordpress/blocks', () => ( {
+			getBlockTypes: jest.fn( () => [
+				1,
+				'string',
+				true,
+				null,
+				undefined,
+				[],
+				{},
+				{ name: 'core/paragraph' },
+				{ category: 'text', name: 'core/paragraph' },
+				{ category: 'image', name: 'core/image' },
+				{ category: 'text', name: 'core/pullquote' },
+				{ category: 'text', name: 'core/preformatted' },
+			] ),
+		} ) );
+
+		const { getTextBlocks } = require( '../src/core/utils' );
+
 		const blocks = getTextBlocks();
+
 		expect( blocks.length ).toBe( 3 );
+	} );
+
+	it( 'getTextBlocks passes and returns default Text Blocks', () => {
+		jest.doMock( '@wordpress/blocks', () => ( {
+			getBlockTypes: jest.fn( () => [] ),
+		} ) );
+
+		const { getTextBlocks } = require( '../src/core/utils' );
+
+		const blocks = getTextBlocks();
+
+		expect( blocks ).toEqual( [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/list-item',
+			'core/quote',
+			'core/code',
+			'core/details',
+			'core/missing',
+			'core/preformatted',
+			'core/pullquote',
+			'core/table',
+			'core/verse',
+			'core/footnotes',
+			'core/freeform',
+		] );
+		expect( blocks.length ).toBe( 14 );
+	} );
+
+	it( 'getShorcut passes and returns default Shortcut', () => {
+		const { getShortcut } = require( '../src/core/utils' );
+
+		const shortcut = getShortcut();
+
+		expect( shortcut ).toEqual( {
+			character: 'f',
+			modifier: 'primaryShift',
+		} );
+	} );
+
+	it( 'getShorcut passes and returns custom Shortcut', () => {
+		const filter = {
+			character: 'K',
+			modifier: 'primaryAlt',
+		};
+
+		jest.doMock( '@wordpress/hooks', () => ( {
+			applyFilters: jest.fn( ( arg ) => ( { ...filter } ) ),
+		} ) );
+
+		const { getShortcut } = require( '../src/core/utils' );
+
+		const shortcut = getShortcut();
+
+		expect( shortcut ).toEqual( {
+			character: 'K',
+			modifier: 'primaryAlt',
+		} );
+	} );
+
+	it( 'getAppRoot returns an instance of HTMLDivElement', () => {
+		const { getAppRoot } = require( '../src/core/utils' );
+
+		const parent: HTMLElement = document.createElement( 'div' );
+		const root = getAppRoot( parent );
+
+		expect( root ).toBeInstanceOf( HTMLDivElement );
+		expect( root ).toHaveProperty( 'id', 'search-replace' );
+		expect( parent ).toContainElement( root );
+	} );
+
+	it( 'isSelectionInModal returns false by default if Selection is not made', () => {
+		const { isSelectionInModal } = require( '../src/core/utils' );
+
+		const status = isSelectionInModal();
+
+		expect( status ).toBe( false );
+		expect( status ).toBeFalsy();
+	} );
+
+	it( 'getBlockEditorIframe returns an instance of Document', () => {
+		const { getBlockEditorIframe } = require( '../src/core/utils' );
+
+		const iframe = getBlockEditorIframe();
+
+		expect( iframe ).toBeInstanceOf( Document );
+	} );
+
+	it( 'isWpVersion returns true if WP version is up to or above passed in arg version', () => {
+		window.srfbe = {
+			wpVersion: '6.7.2',
+		};
+
+		const { isWpVersion } = require( '../src/core/utils' );
+
+		const status = isWpVersion( '6.7.0' );
+
+		expect( status ).toBe( true );
+		expect( status ).toBeTruthy();
+	} );
+
+	it( 'isWpVersion returns false if WP version is not up to passed in arg version', () => {
+		window.srfbe = {
+			wpVersion: '6.7.0',
+		};
+
+		const { isWpVersion } = require( '../src/core/utils' );
+
+		const status = isWpVersion( '6.7.1' );
+
+		expect( status ).toBe( false );
+		expect( status ).toBeFalsy();
+	} );
+
+	it( 'isWpVersion returns false if param version number is not valid', () => {
+		window.srfbe = {
+			wpVersion: '2.3',
+		};
+
+		const { isWpVersion } = require( '../src/core/utils' );
+
+		const status = isWpVersion( '6.7' );
+
+		expect( status ).toBe( false );
+		expect( status ).toBeFalsy();
+	} );
+
+	it( 'isWpVersion returns false if one of params is invalid version number without dot notation', () => {
+		window.srfbe = {
+			wpVersion: '67',
+		};
+
+		const { isWpVersion } = require( '../src/core/utils' );
+
+		const status = isWpVersion( '6.3.2' );
+
+		expect( status ).toBe( false );
+		expect( status ).toBeFalsy();
+	} );
+
+	it( 'isWpVersion returns false if param is not string', () => {
+		const { isWpVersion } = require( '../src/core/utils' );
+
+		const status = isWpVersion( 7 );
+
+		expect( status ).toBe( false );
+		expect( status ).toBeFalsy();
+	} );
+
+	it( 'getNumberToBase10 returns the correct Radix', () => {
+		const { getNumberToBase10 } = require( '../src/core/utils' );
+
+		const radix = getNumberToBase10( [ 5, 6, 1 ] );
+
+		expect( radix ).toBe( 561 );
+		expect( radix ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'getNumberToBase10 receives non-array param and returns zero', () => {
+		const { getNumberToBase10 } = require( '../src/core/utils' );
+
+		const radix = getNumberToBase10( 'non-array' );
+
+		expect( radix ).toBe( 0 );
+		expect( radix ).toBeFalsy();
+	} );
+
+	it( 'getNumberToBase10 receives mixed array type and returns zero', () => {
+		const { getNumberToBase10 } = require( '../src/core/utils' );
+
+		const radix = getNumberToBase10( [ 1, 'zero', 2 ] );
+
+		expect( radix ).toBe( 0 );
+		expect( radix ).toBeFalsy();
+	} );
+
+	it( 'getFallbackTextBlocks gets array of default fallback text blocks', () => {
+		const { getFallbackTextBlocks } = require( '../src/core/utils' );
+
+		const fallbackTextBlocks = getFallbackTextBlocks();
+
+		expect( fallbackTextBlocks.length ).toBe( 14 );
+		expect( fallbackTextBlocks ).toBeInstanceOf( Array );
+	} );
+
+	it( 'getShorcutEvent returns the instance of a Keyboard Event', () => {
+		const { getShortcutEvent } = require( '../src/core/utils' );
+
+		const shortcutEvent = getShortcutEvent();
+
+		expect( shortcutEvent ).toBeInstanceOf( KeyboardEvent );
 	} );
 } );

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -4,7 +4,7 @@ interface Window {
 	};
 }
 
-describe( 'getTextBlocks', () => {
+describe( 'getAllowedBlocks', () => {
 	beforeEach( () => {
 		jest.resetModules();
 	} );
@@ -49,6 +49,12 @@ describe( 'getTextBlocks', () => {
 		const blocks = getAllowedBlocks();
 
 		expect( blocks.length ).toBe( 3 );
+	} );
+} );
+
+describe( 'getTextBlocks', () => {
+	beforeEach( () => {
+		jest.resetModules();
 	} );
 
 	it( 'getTextBlocks passes and returns Blocks in the `text` category', () => {
@@ -132,6 +138,12 @@ describe( 'getTextBlocks', () => {
 		] );
 		expect( blocks.length ).toBe( 14 );
 	} );
+} );
+
+describe( 'getShortcut', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'getShorcut passes and returns default Shortcut', () => {
 		const { getShortcut } = require( '../src/core/utils' );
@@ -163,6 +175,12 @@ describe( 'getTextBlocks', () => {
 			modifier: 'primaryAlt',
 		} );
 	} );
+} );
+
+describe( 'getAppRoot', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'getAppRoot returns an instance of HTMLDivElement', () => {
 		const { getAppRoot } = require( '../src/core/utils' );
@@ -174,6 +192,12 @@ describe( 'getTextBlocks', () => {
 		expect( root ).toHaveProperty( 'id', 'search-replace' );
 		expect( parent ).toContainElement( root );
 	} );
+} );
+
+describe( 'isSelectionModal', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'isSelectionInModal returns false by default if Selection is not made', () => {
 		const { isSelectionInModal } = require( '../src/core/utils' );
@@ -183,6 +207,12 @@ describe( 'getTextBlocks', () => {
 		expect( status ).toBe( false );
 		expect( status ).toBeFalsy();
 	} );
+} );
+
+describe( 'getBlockEditorIframe', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'getBlockEditorIframe returns an instance of Document', () => {
 		const { getBlockEditorIframe } = require( '../src/core/utils' );
@@ -190,6 +220,12 @@ describe( 'getTextBlocks', () => {
 		const iframe = getBlockEditorIframe();
 
 		expect( iframe ).toBeInstanceOf( Document );
+	} );
+} );
+
+describe( 'isWpVersion', () => {
+	beforeEach( () => {
+		jest.resetModules();
 	} );
 
 	it( 'isWpVersion returns true if WP version is up to or above passed in arg version', () => {
@@ -252,6 +288,12 @@ describe( 'getTextBlocks', () => {
 		expect( status ).toBe( false );
 		expect( status ).toBeFalsy();
 	} );
+} );
+
+describe( 'getNumberToBase10', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'getNumberToBase10 returns the correct Radix', () => {
 		const { getNumberToBase10 } = require( '../src/core/utils' );
@@ -279,6 +321,12 @@ describe( 'getTextBlocks', () => {
 		expect( radix ).toBe( 0 );
 		expect( radix ).toBeFalsy();
 	} );
+} );
+
+describe( 'getFallbackTextBlocks', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
 
 	it( 'getFallbackTextBlocks gets array of default fallback text blocks', () => {
 		const { getFallbackTextBlocks } = require( '../src/core/utils' );
@@ -287,6 +335,12 @@ describe( 'getTextBlocks', () => {
 
 		expect( fallbackTextBlocks.length ).toBe( 14 );
 		expect( fallbackTextBlocks ).toBeInstanceOf( Array );
+	} );
+} );
+
+describe( 'getShortcutEvent', () => {
+	beforeEach( () => {
+		jest.resetModules();
 	} );
 
 	it( 'getShorcutEvent returns the instance of a Keyboard Event', () => {


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/48).

## Description / Background Context

We have quite a bunch of methods that have not been tested yet. We'll need to write test cases to cover those bases to prevent unexpected behaviours within our component.

For e.g. our getAppRoot util method:

```js
it( 'getAppRoot returns an instance of HTMLDivElement', () => {
    const { getAppRoot } = require( '../src/core/utils' );
    
    const parent: HTMLElement = document.createElement( 'div' );
    const root = getAppRoot( parent );
    
    expect( root ).toBeInstanceOf( HTMLDivElement );
    expect( root ).toHaveProperty( 'id', 'search-replace' );
    expect( parent ).toContainElement( root );
} );
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Run tests like so: `yarn test:js`.
3. All tests should pass successfully like so:

<img width="689" alt="Screenshot 2025-03-05 at 01 15 52" src="https://github.com/user-attachments/assets/9e3c47ba-e644-455a-b42b-686f95c64a8a" />