### PR TITLE
Refactor: use replaceBlockAttribute hook for search and replace logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Feat: Add search icon to Toolbar.
 * Chore: Enforce WP linting across plugin.
 * Test: Improve unit tests cases.
+* Refactor: Search & Replace core logic to use `replaceBlockAttribute` hook.
 * Tested up to WP 6.7.2.
 
 ## 1.3.0

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Feat: Add search icon to Toolbar.
 * Chore: Enforce WP linting across plugin.
 * Test: Improve unit tests cases.
+* Refactor: Search & Replace core logic to use `replaceBlockAttribute` hook.
 * Tested up to WP 6.7.2.
 
 = 1.3.0 =

--- a/src/core/filters.tsx
+++ b/src/core/filters.tsx
@@ -1,0 +1,40 @@
+import { addAction } from '@wordpress/hooks';
+
+/**
+ * Replace Block Attribute.
+ *
+ * This function replaces the block attribute
+ * based on the block name.
+ *
+ * @since 1.4.0
+ *
+ * @param {Function} replaceBlockAttribute Replace Block Attribute.
+ * @param {string}   name                  Block Name.
+ * @param {any}      args                  Block Arguments.
+ *
+ * @return {void}
+ */
+addAction(
+	'search-replace-for-block-editor.replaceBlockAttribute',
+	'yourBlock',
+	( replaceBlockAttribute, name, args ) => {
+		switch ( name ) {
+			case 'core/quote':
+				replaceBlockAttribute( args, 'citation' );
+				break;
+
+			case 'core/pullquote':
+				replaceBlockAttribute( args, 'value' );
+				replaceBlockAttribute( args, 'citation' );
+				break;
+
+			case 'core/details':
+				replaceBlockAttribute( args, 'summary' );
+				break;
+
+			default:
+				replaceBlockAttribute( args, 'content' );
+				break;
+		}
+	}
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
 import './core/toolbar';
+import './core/filters';
 import SearchReplaceForBlockEditor from './core/app';
 import { getAppRoot, getEditorRoot, isWpVersion } from './core/utils';
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/50).

## Description / Background Context

Based on @sdonkers [PR](https://github.com/badasswp/search-and-replace/pull/42) we need to refactor our original search and replace implementation to now use the action hook `replaceBlockAttribute` in place of our original search and replace implementation.

```js
import { addAction } from '@wordpress/hooks';

addAction(
    'search-replace-for-block-editor.replaceBlockAttribute',
    'yourBlock',
    ( replaceBlockAttribute, name, args ) => {
        switch ( name ) {
            case 'core/quote':
            	replaceBlockAttribute( args, 'citation' );
            	break;
            
            case 'core/pullquote':
            	replaceBlockAttribute( args, 'value' );
            	replaceBlockAttribute( args, 'citation' );
            	break;
            
            case 'core/details':
            	replaceBlockAttribute( args, 'summary' );
            	break;
            
            default:
            	replaceBlockAttribute( args, 'content' );
            	break;
        }
    }
);
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn dev`.
3. Open a post, type in some paragraphs and perform search and replace.
4. All features should work correctly as before without any regressions.