### PR TITLE
Fix: Icon missing due to the recent WP 6.8 upgrade

### DIFF
--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -17,7 +17,7 @@ import {
 	getBlockEditorIframe,
 	isCaseSensitive,
 	isSelectionInModal,
-	isWpVersion,
+	isWpVersionGreaterThanOrEqualTo,
 } from './utils';
 
 import '../styles/app.scss';
@@ -281,7 +281,9 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 * @return {JSX.Element|null} Shortcut.
 	 */
 	const SafeShortcut = (): JSX.Element | null =>
-		isWpVersion( '6.4.0' ) ? <Shortcut onKeyDown={ openModal } /> : null;
+		isWpVersionGreaterThanOrEqualTo( '6.4.0' ) ? (
+			<Shortcut onKeyDown={ openModal } />
+		) : null;
 
 	return (
 		<>

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -225,6 +225,26 @@ export const isSelectionInModal = (): boolean => {
 };
 
 /**
+ * Standardize Version.
+ *
+ * This function takes an array of version numbers
+ * and ensures that it has exactly three elements.
+ *
+ * @since 1.5.0
+ *
+ * @param {number[]} versionArray - Array of version numbers.
+ * @return {number[]} Standardized version array.
+ */
+export const standardizeVersion = ( versionArray: number[] ): number[] => {
+	const standardizedVersion = [ ...versionArray ];
+	while ( standardizedVersion.length < 3 ) {
+		standardizedVersion.push( 0 );
+	}
+
+	return standardizedVersion;
+};
+
+/**
  * Check if it's up to WP version.
  *
  * @since 1.2.2
@@ -240,12 +260,12 @@ export const isWpVersionGreaterThanOrEqualTo = ( version: string ): boolean => {
 	const argVersion = version;
 	const { wpVersion: sysVersion } = srfbe as { wpVersion: string };
 
-	const argVersionArray = argVersion.split( '.' ).map( Number );
-	const sysVersionArray = sysVersion.split( '.' ).map( Number );
-
-	if ( argVersionArray?.length !== 3 || sysVersionArray?.length !== 3 ) {
-		return false;
-	}
+	const argVersionArray = standardizeVersion(
+		argVersion.split( '.' ).map( Number )
+	);
+	const sysVersionArray = standardizeVersion(
+		sysVersion.split( '.' ).map( Number )
+	);
 
 	const argVersionRadix: number = getNumberToBase10( argVersionArray );
 	const sysVersionRadix: number = getNumberToBase10( sysVersionArray );

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -149,7 +149,7 @@ export const getEditorRoot = (): Promise< HTMLElement | Error > => {
 				resolve( root );
 			}
 
-			if ( elapsedTime > 600 * interval ) {
+			if ( elapsedTime > 100 * interval ) {
 				clearInterval( intervalId );
 				reject( new Error( 'Unable to get Editor root container...' ) );
 			}

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -133,7 +133,7 @@ export const getEditorRoot = (): Promise< HTMLElement | Error > => {
 	let elapsedTime: number = 0;
 	const interval: number = 100;
 
-	const selector: string = isWpVersion( '6.6.0' )
+	const selector: string = isWpVersionGreaterThanOrEqualTo( '6.6.0' )
 		? '.editor-header__toolbar'
 		: '.edit-post-header__toolbar';
 
@@ -232,7 +232,7 @@ export const isSelectionInModal = (): boolean => {
  * @param {string} version WP Version.
  * @return {boolean} Is WP Version.
  */
-export const isWpVersion = ( version: string ): boolean => {
+export const isWpVersionGreaterThanOrEqualTo = ( version: string ): boolean => {
 	if ( typeof version !== 'string' ) {
 		return false;
 	}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,12 +8,16 @@ import { createRoot } from 'react-dom/client';
 import './core/toolbar';
 import './core/filters';
 import SearchReplaceForBlockEditor from './core/app';
-import { getAppRoot, getEditorRoot, isWpVersion } from './core/utils';
+import {
+	getAppRoot,
+	getEditorRoot,
+	isWpVersionGreaterThanOrEqualTo,
+} from './core/utils';
 
 ( async () => {
 	try {
 		const app = getAppRoot( ( await getEditorRoot() ) as HTMLElement );
-		if ( ! isWpVersion( '6.2.0' ) ) {
+		if ( ! isWpVersionGreaterThanOrEqualTo( '6.2.0' ) ) {
 			ReactDOM.render( <SearchReplaceForBlockEditor />, app );
 		} else {
 			createRoot( app ).render( <SearchReplaceForBlockEditor /> );

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 interface Window {
 	srfbe: {
 		wpVersion: string;
@@ -163,7 +164,7 @@ describe( 'getShortcut', () => {
 		};
 
 		jest.doMock( '@wordpress/hooks', () => ( {
-			applyFilters: jest.fn( ( arg ) => ( { ...filter } ) ),
+			applyFilters: jest.fn( () => ( { ...filter } ) ),
 		} ) );
 
 		const { getShortcut } = require( '../src/core/utils' );

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -223,67 +223,92 @@ describe( 'getBlockEditorIframe', () => {
 	} );
 } );
 
-describe( 'isWpVersion', () => {
+describe( 'isWpVersionGreaterThanOrEqualTo', () => {
 	beforeEach( () => {
 		jest.resetModules();
 	} );
 
-	it( 'isWpVersion returns true if WP version is up to or above passed in arg version', () => {
+	it( 'isWpVersionGreaterThanOrEqualTo returns true if WP version is up to or above passed in arg version', () => {
 		window.srfbe = {
 			wpVersion: '6.7.2',
 		};
 
-		const { isWpVersion } = require( '../src/core/utils' );
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
 
-		const status = isWpVersion( '6.7.0' );
+		const status = isWpVersionGreaterThanOrEqualTo( '6.7.0' );
 
 		expect( status ).toBe( true );
 		expect( status ).toBeTruthy();
 	} );
 
-	it( 'isWpVersion returns false if WP version is not up to passed in arg version', () => {
+	it( 'isWpVersionGreaterThanOrEqualTo returns false if WP version is not up to passed in arg version', () => {
 		window.srfbe = {
 			wpVersion: '6.7.0',
 		};
 
-		const { isWpVersion } = require( '../src/core/utils' );
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
 
-		const status = isWpVersion( '6.7.1' );
+		const status = isWpVersionGreaterThanOrEqualTo( '6.7.1' );
 
 		expect( status ).toBe( false );
 		expect( status ).toBeFalsy();
 	} );
 
-	it( 'isWpVersion returns false if param version number is not valid', () => {
+	it( 'isWpVersionGreaterThanOrEqualTo returns false if param version number is not valid', () => {
 		window.srfbe = {
 			wpVersion: '2.3',
 		};
 
-		const { isWpVersion } = require( '../src/core/utils' );
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
 
-		const status = isWpVersion( '6.7' );
+		const status = isWpVersionGreaterThanOrEqualTo( '6.7' );
 
 		expect( status ).toBe( false );
 		expect( status ).toBeFalsy();
 	} );
 
-	it( 'isWpVersion returns false if one of params is invalid version number without dot notation', () => {
+	it( 'isWpVersionGreaterThanOrEqualTo returns true if one of params has version number without dot notation but is equal to or greater than version number', () => {
 		window.srfbe = {
 			wpVersion: '67',
 		};
 
-		const { isWpVersion } = require( '../src/core/utils' );
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
 
-		const status = isWpVersion( '6.3.2' );
+		const status = isWpVersionGreaterThanOrEqualTo( '6.3.2' );
 
-		expect( status ).toBe( false );
-		expect( status ).toBeFalsy();
+		expect( status ).toBe( true );
+		expect( status ).toBeTruthy();
 	} );
 
-	it( 'isWpVersion returns false if param is not string', () => {
-		const { isWpVersion } = require( '../src/core/utils' );
+	it( 'isWpVersionGreaterThanOrEqualTo returns true if one of params has version number with single dot notation but is equal to or greater than version number', () => {
+		window.srfbe = {
+			wpVersion: '6.8',
+		};
 
-		const status = isWpVersion( 7 );
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
+
+		const status = isWpVersionGreaterThanOrEqualTo( '6.3.2' );
+
+		expect( status ).toBe( true );
+		expect( status ).toBeTruthy();
+	} );
+
+	it( 'isWpVersionGreaterThanOrEqualTo returns false if param is not string', () => {
+		const {
+			isWpVersionGreaterThanOrEqualTo,
+		} = require( '../src/core/utils' );
+
+		const status = isWpVersionGreaterThanOrEqualTo( 7 );
 
 		expect( status ).toBe( false );
 		expect( status ).toBeFalsy();


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/54).

## Description / Background Context

There is a noticeable regression with the recent WP 6.8 upgrade. The Search & Replace icon appears to be missing from the top left icon of the WP Block Editor. This is caused by the isWpVersion function. It doesn't accurately capture and handle WP versions with less than 3 numbers such as `6.8` as shown here:

```bash
if ( argVersionArray?.length !== 3 || sysVersionArray?.length !== 3 ) {
    return false;
}
```

This PR implements a fix for this.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Head over to the WP Block Editor.
4. The Search and Replace icon should now be visible once again at the top left corner of the WP Block Editor.