### PR TITLE
Feat: Add Table block search and replace logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0
+* Feat: Add search and replace functionality for __Table Block__.
+* Feat: Add new custom hook `search-replace-for-block-editor.handleAttributeReplacement`.
+* Docs: Update README docs.
+* Tested up to WP 6.8.
+
 ## 1.5.0
 * Fix: Missing icon due to recent WP 6.8 upgrade.
 * Feat: Add local WP dev env.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,47 @@ addAction(
 - args _`{Object}`_ By default, this is an object containing the `element`, `pattern`, `text` and `status`.
 <br/>
 
+#### `search-replace-for-block-editor.handleAttributeReplacement`
+
+This custom hook (filter) provides a way to modify how the search and replace functionality works for custom attributes for e.g. non-text attributes or objects.
+
+```js
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'search-replace-for-block-editor.handleAttributeReplacement',
+	'yourNamespace',
+	( oldAttr, args ) => {
+		const { name, pattern, handleAttributeReplacement } = args;
+
+		if ( 'your-custom-block' === name ) {
+			const newAttr = oldAttr.replace(
+				pattern,
+				handleAttributeReplacement
+			);
+
+			return {
+				newAttr,
+				isChanged: oldAttr === newAttr,
+			};
+		}
+
+		return {
+			newAttr: oldAttr,
+			isChanged: false,
+		};
+	}
+);
+```
+
+**Parameters**
+
+- oldAttr _`{any}`_ Old Attribute.
+- name _`{string}`_ Name of Block.
+- pattern _`{RegExp}`_ Regular Expression pattern.
+- handleAttributeReplacement _`{Function}`_ Replace Callback.
+<br/>
+
 #### `search-replace-for-block-editor.keyboardShortcut`
 
 This custom hook (filter) provides a way for users to specify their preferred keyboard shortcut option. For e.g to use the 'K' option on your keyboard, you could do like so:

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { search } from '@wordpress/icons';
-import { doAction } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 import { dispatch, select } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import {
@@ -190,10 +190,13 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	 */
 	const replaceBlockAttribute = ( args: any, attribute: string ): void => {
 		const property = {};
-		const { pattern, text, element, status } = args;
-		const { attributes, clientId } = element;
+		const {
+			pattern,
+			text,
+			element: { attributes, clientId, name },
+			status,
+		} = args;
 
-		// Bail out, if attribute is not defined.
 		if (
 			undefined === attributes ||
 			undefined === attributes[ attribute ]
@@ -201,22 +204,47 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 			return;
 		}
 
-		// Get and replace matched strings.
-		const oldString: string =
-			attributes[ attribute ].text || attributes[ attribute ];
+		const oldAttr = attributes[ attribute ].text || attributes[ attribute ];
 
-		const newString: string = oldString.replace( pattern, () => {
-			setReplacements( ( items ) => items + 1 );
+		/**
+		 * Replace Callback.
+		 *
+		 * @return {string} Replacement Text.
+		 */
+		const handleAttributeReplacement = (): string => {
+			setReplacements( ( items: number ) => items + 1 );
 			return text;
-		} );
+		};
 
-		// Bail out, if no change.
-		if ( newString === oldString ) {
+		/**
+		 * Filter the way we handle the attribute replacement
+		 * to cater for special types of blocks.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param {any}      oldAttr                    Old Attribute.
+		 * @param {string}   name                       Block Name.
+		 * @param {RegExp}   pattern                    Search pattern.
+		 * @param {Function} handleAttributeReplacement Handle Attribute Replacement.
+		 *
+		 * @return {Object}
+		 */
+		const { newAttr, isChanged } = applyFilters(
+			'search-replace-for-block-editor.handleAttributeReplacement',
+			oldAttr,
+			{
+				name,
+				pattern,
+				handleAttributeReplacement,
+			}
+		) as { newAttr: any; isChanged: boolean };
+
+		if ( ! isChanged ) {
 			return;
 		}
 
 		// Set the property attribute.
-		property[ attribute ] = newString;
+		property[ attribute ] = newAttr;
 
 		// Update block property or content (if replace).
 		if ( status ) {

--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -33,12 +33,12 @@ import '../styles/app.scss';
  * @return {JSX.Element} Search & Replace for Block Editor.
  */
 const SearchReplaceForBlockEditor = (): JSX.Element => {
-	const [ replacements, setReplacements ] = useState( 0 );
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
-	const [ searchInput, setSearchInput ] = useState( '' );
-	const [ replaceInput, setReplaceInput ] = useState( '' );
-	const [ caseSensitive, setCaseSensitive ] = useState( false );
-	const [ context, setContext ] = useState( false );
+	const [ replacements, setReplacements ] = useState< number >( 0 );
+	const [ isModalVisible, setIsModalVisible ] = useState< boolean >( false );
+	const [ searchInput, setSearchInput ] = useState< string >( '' );
+	const [ replaceInput, setReplaceInput ] = useState< string >( '' );
+	const [ caseSensitive, setCaseSensitive ] = useState< boolean >( false );
+	const [ context, setContext ] = useState< boolean >( false );
 
 	/**
 	 * Open Modal.

--- a/src/core/filters.tsx
+++ b/src/core/filters.tsx
@@ -1,4 +1,4 @@
-import { addAction } from '@wordpress/hooks';
+import { addAction, addFilter } from '@wordpress/hooks';
 
 /**
  * Replace Block Attribute.
@@ -16,7 +16,7 @@ import { addAction } from '@wordpress/hooks';
  */
 addAction(
 	'search-replace-for-block-editor.replaceBlockAttribute',
-	'yourBlock',
+	'srfbe',
 	( replaceBlockAttribute, name, args ) => {
 		switch ( name ) {
 			case 'core/quote':
@@ -32,9 +32,58 @@ addAction(
 				replaceBlockAttribute( args, 'summary' );
 				break;
 
+			case 'core/table':
+				replaceBlockAttribute( args, 'body' );
+				break;
+
 			default:
 				replaceBlockAttribute( args, 'content' );
 				break;
+		}
+	}
+);
+
+/**
+ * Filter the way we handle the attribute replacement
+ * to cater for special types of blocks.
+ *
+ * @since 1.6.0
+ *
+ * @param {any}      oldAttr                    Old Attribute.
+ * @param {string}   name                       Block Name.
+ * @param {RegExp}   pattern                    Search pattern.
+ * @param {Function} handleAttributeReplacement Handle Attribute Replacement.
+ *
+ * @return {Object}
+ */
+addFilter(
+	'search-replace-for-block-editor.handleAttributeReplacement',
+	'srfbe',
+	( oldAttr, args ) => {
+		const { name, pattern, handleAttributeReplacement } = args;
+
+		switch ( name ) {
+			case 'core/table':
+				const tableString: string = JSON.stringify( oldAttr ).replace(
+					pattern,
+					handleAttributeReplacement
+				);
+
+				return {
+					newAttr: JSON.parse( tableString ),
+					isChanged: tableString !== JSON.stringify( oldAttr ),
+				};
+
+			default:
+				const defaultString: string = oldAttr.replace(
+					pattern,
+					handleAttributeReplacement
+				);
+
+				return {
+					newAttr: defaultString,
+					isChanged: defaultString !== oldAttr,
+				};
 		}
 	}
 );


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/search-and-replace/issues/18).

## Description / Background Context

As raised by [@anandraj346](https://github.com/anandraj346)

When users try to perform Search & Replace operations in the Table block, we see that it doesn't work correctly as expected. This is because the previous implementation: `replaceBlockAttribute` does not accurately capture it's edge-case and so would require its own custom implementation.

This PR implements this feature correctly.

<img width="1166" alt="Screenshot 2024-11-27 at 14 45 47" src="https://github.com/user-attachments/assets/3d6f45c7-f560-43a0-b3b3-4e168434cfa6">

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start && yarn build`.
3. Create a table within the WP block editor.
4. Perform a search and replace action for strings in the table.
5. Observe that strings are replaced correctly for the table block.
6. Observe that there are no regressions whatsoever.