### PR TITLE
Fix: Issue with rich content replacement

### DIFF
--- a/src/core/app.tsx
+++ b/src/core/app.tsx
@@ -95,7 +95,13 @@ const SearchReplaceForBlockEditor = (): JSX.Element => {
 	}, [ searchInput, caseSensitive ] );
 
 	/**
-	 * Focus handling
+	 * Modal Focus.
+	 *
+	 * Automatically focus the user's cursor on the
+	 * modal's first text-field input when the modal
+	 * becomes visible.
+	 *
+	 * @since 1.7.0
 	 */
 	useEffect( () => {
 		if ( isModalVisible && searchFieldRef.current ) {


### PR DESCRIPTION
This PR fixes 2 issues:
1. Bugfix for the issue search and replace removing the html of a block. 
See issue https://github.com/badasswp/search-and-replace/issues/61
2. Setting the cursor is to the searchfield when opening the S&R modal.
 

