### PR TITLE
Docs: Update Shortcut notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.10.1
+* Docs: Update doc blocks.
+
 ## 1.10.0
 * Feat: Added translation languages for `Japanese`,`Indonesian`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Feat: Add toggle for Regex expression matching.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ addFilter(
 
 **Parameters**
 
-- shortcut _`{Object}`_ By default this is an object, containing `modifier` and `character` properties which together represent the following command `CMD + SHIFT + F`.
+- shortcut _`{Object}`_ By default this is an object, containing `modifier` and `character` properties which together represent the following command `CMD + F`.
 <br/>
 
 #### `search-replace-for-block-editor.caseSensitive`

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.10.1 =
+* Docs: Update doc blocks.
+
 = 1.10.0 =
 * Feat: Added translation languages for `Japanese`,`Indonesian`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Feat: Add toggle for Regex expression matching.

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Now you can easily search and replace text right in the Block Editor. Its easy a
 Our plugin comes with everything you need to find and replace text quicker and more efficiently.
 
 ✔️ <strong>Search & Replace</strong> text, typos, keywords faster.
-✔️ <strong>Shortcut Keys</strong> - CMD + SHIFT + F.
+✔️ <strong>Shortcut Keys</strong> - CMD + F.
 ✔️ <strong>Match Case</strong> Sensitivity.
 ✔️ <strong>Custom Hooks</strong> to help you customize plugin behaviour.
 ✔️ Available in <strong>mutiple langauges</strong> such as Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ You can get a taste of how this works, by using the [demo](https://tastewp.com/c
 
 = ⚡ Shortcut Keys & Text Selection =
 
-To quickly access the Search and Replace modal, press <strong>CTRL + SHIFT + F</strong>. This will fire up the dialog box where you can quickly change things.
+To quickly access the Search and Replace modal, press <strong>CTRL + F</strong>. This will fire up the dialog box where you can quickly change things.
 
 You can also <strong>select text</strong> on your Block Editor and <strong>use the Shortcut</strong>. This will grab the text you have selected and fire up your dialog box with the text already typed into it. This makes working with the Search and Replace tool faster.
 

--- a/src/core/shortcut.tsx
+++ b/src/core/shortcut.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -28,7 +29,10 @@ export const Shortcut = ( {
 		name: 'search-replace-for-block-editor/shortcut',
 		keyCombination: getShortcut(),
 		category: 'global',
-		description: 'Search & Replace',
+		description: __(
+			'Search & Replace',
+			'search-replace-for-block-editor'
+		),
 	} );
 
 	useShortcut(

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -82,8 +82,8 @@ export const getShortcut = (): { modifier: string; character: string } => {
 	/**
 	 * Filter Keyboard Shortcut.
 	 *
-	 * By default the passed option would be SHIFT which
-	 * represents `CMD + SHIFT + F`.
+	 * By default the passed option would be CMD which
+	 * represents `CMD + F`.
 	 *
 	 * @since 1.0.1
 	 *

--- a/src/typings/styles.d.ts
+++ b/src/typings/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.scss';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
+		"rootDir": "./src",
     "outDir": "./build",
     "jsx": "react-jsx",
     "module": "ESNext",
-    "target": "ES2015",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "sourceMap": true,
     "noImplicitAny": false,
@@ -14,7 +14,6 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": false,
     "noImplicitThis": true,
-    "alwaysStrict": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": false,
@@ -25,7 +24,9 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "target": "es2017",
+    "lib": ["es2017", "dom"]
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-		"rootDir": "./src",
+    "rootDir": "./src",
     "outDir": "./build",
     "jsx": "react-jsx",
     "module": "ESNext",


### PR DESCRIPTION
This PR resolves [WP-200](https://appworld.atlassian.net/browse/WP-200).

## Description / Background Context

When we rolled out `release-1.10.0`, we forgot to update some of the Shortcut notes. This PR resolves this issue.

## Testing Instructions

- Pull PR to local.
- Run `yarn build` to build correctly.
- Proceed to Posts and locate icon.
- Perform Search & Replace activity using any article of your choice.
- Observe that there are no regressions introduced.
