### PR TITLE
Feat: Add more plugins options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.0
+* Feat: Add `More Plugins` options page.
+
 ## 1.10.3
 * Tested up to WP 7.0.
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
 			"email": "badasswpdev@gmail.com"
 		}
 	],
+	"require": {
+		"badasswp/pluginate": "^1.0"
+	},
 	"require-dev": {
 		"badasswp/wp-mock-tc": "^1.0",
 		"phpunit/phpunit": "^9.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -15,7 +15,27 @@ use SearchReplaceForBlockEditor\Admin\Options;
 use SearchReplaceForBlockEditor\Abstracts\Service;
 use SearchReplaceForBlockEditor\Interfaces\Kernel;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Kernel {
+	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.11.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'search-replace-for-block-editor' );
+	}
+
 	/**
 	 * Bind to WP.
 	 *
@@ -27,6 +47,7 @@ class Admin extends Service implements Kernel {
 		add_action( 'admin_init', [ $this, 'register_options_init' ] );
 		add_action( 'admin_menu', [ $this, 'register_options_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_options_styles' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -52,6 +73,15 @@ class Admin extends Service implements Kernel {
 			),
 			100
 		);
+
+		add_submenu_page(
+			Options::get_page_slug(),
+			__( 'More Plugins', 'search-replace-for-block-editor' ),
+			__( 'More Plugins', 'search-replace-for-block-editor' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', Options::get_page_slug() ),
+			[ $this, 'register_more_plugins' ]
+		);
 	}
 
 	/**
@@ -74,6 +104,35 @@ class Admin extends Service implements Kernel {
 			array_map(
 				'__',
 				( new Form( Options::$form ) )->get_options()
+			)
+		);
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
 			)
 		);
 	}
@@ -136,7 +195,7 @@ class Admin extends Service implements Kernel {
 		$screen = get_current_screen();
 
 		// Bail out, if not plugin Admin page.
-		if ( ! is_object( $screen ) || 'toplevel_page_search-replace-for-block-editor' !== $screen->id ) {
+		if ( ! is_object( $screen ) || ! str_contains( $screen->id, Options::get_page_slug() ) ) {
 			return;
 		}
 

--- a/tests/unit/php/Core/ContainerTest.php
+++ b/tests/unit/php/Core/ContainerTest.php
@@ -3,7 +3,6 @@
 namespace SearchReplaceForBlockEditor\Tests\Core;
 
 use WP_Mock;
-use Mockery;
 use WP_Mock\Tools\TestCase;
 
 use SearchReplaceForBlockEditor\Core\Container;
@@ -17,6 +16,7 @@ use SearchReplaceForBlockEditor\Abstracts\Service;
  * @covers \SearchReplaceForBlockEditor\Services\Admin::register
  * @covers \SearchReplaceForBlockEditor\Services\Boot::register
  * @covers \SearchReplaceForBlockEditor\Abstracts\Service::get_instance
+ * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -70,6 +70,16 @@ class ContainerTest extends TestCase {
 			[
 				Service::$services[ Admin::class ],
 				'register_options_styles',
+			]
+		);
+
+		$admin = Service::$services[ Admin::class ];
+
+		WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
 			]
 		);
 

--- a/tests/unit/php/PluginTest.php
+++ b/tests/unit/php/PluginTest.php
@@ -3,11 +3,9 @@
 namespace SearchReplaceForBlockEditor\Tests;
 
 use WP_Mock;
-use Mockery;
 use WP_Mock\Tools\TestCase;
 
 use SearchReplaceForBlockEditor\Plugin;
-use SearchReplaceForBlockEditor\Abstracts\Kernel;
 
 /**
  * @covers \SearchReplaceForBlockEditor\Plugin::get_instance

--- a/tests/unit/php/Services/AdminTest.php
+++ b/tests/unit/php/Services/AdminTest.php
@@ -21,6 +21,7 @@ use SearchReplaceForBlockEditor\Services\Admin;
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_page
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_submit
  * @covers \SearchReplaceForBlockEditor\Admin\Options::init
+ * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class AdminTest extends WPMockTestCase {
 	public Admin $admin;
@@ -43,6 +44,7 @@ class AdminTest extends WPMockTestCase {
 		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
 		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
 		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -60,6 +62,21 @@ class AdminTest extends WPMockTestCase {
 				[ $this->admin, 'register_options_page' ],
 				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj4KCQkJCQk8cGF0aCBkPSJNMTMgNWMtMy4zIDAtNiAyLjctNiA2IDAgMS40LjUgMi43IDEuMyAzLjdsLTMuOCAzLjggMS4xIDEuMSAzLjgtMy44YzEgLjggMi4zIDEuMyAzLjcgMS4zIDMuMyAwIDYtMi43IDYtNlMxNi4zIDUgMTMgNXptMCAxMC41Yy0yLjUgMC00LjUtMi00LjUtNC41czItNC41IDQuNS00LjUgNC41IDIgNC41IDQuNS0yIDQuNS00LjUgNC41eiIgLz4KCQkJCTwvc3ZnPg==',
 				100
+			)
+			->andReturn( null );
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing( fn( $text, $domain ) => $text );
+
+		WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'search-replace-for-block-editor',
+				'More Plugins',
+				'More Plugins',
+				'manage_options',
+				'search-replace-for-block-editor-more-plugins',
+				[ $this->admin, 'register_more_plugins' ]
 			)
 			->andReturn( null );
 


### PR DESCRIPTION
This PR resolves [WP-189](https://appworld.atlassian.net/browse/WP-189)

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **Ping Me On Slack** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="119" height="83" alt="Screenshot 2026-06-08 125218" src="https://github.com/user-attachments/assets/7f1c8e4d-622d-468e-aaad-7776b1b01f6c" />

---

<img width="828" height="413" alt="Screenshot 2026-06-08 125257" src="https://github.com/user-attachments/assets/12b6840e-050b-4d78-ab75-b6d4cb989ea5" />
