### PR TITLE
Fix enqueueing editor scrips when loaded as mu-plugin.

### DIFF
--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -60,7 +60,7 @@ class Boot extends Service implements Kernel {
 
 		wp_enqueue_script(
 			Options::get_page_slug(),
-			plugins_url( sprintf( '%s/dist/app.js', Options::get_page_slug() ) ),
+			plugins_url( 'dist/app.js', dirname( __DIR__ ) ),
 			$assets['dependencies'],
 			$assets['version'],
 			false,


### PR DESCRIPTION
This PR resolves #98.

## Description / Background Context

If the plugin is installed as mu-plugin the `dist/app.js` script is not enqueued properly.

## Testing Instructions

1. Install the plugin in `mu-plugins` and load it from that folder.
2. Edit a post.
3. The plugin icon should appear in the editor toolbar.

## Screenshots / Screencast

<img width="312" height="83" alt="Screenshot 2026-08-12 at 00 50 36" src="https://github.com/user-attachments/assets/e1055e82-7a12-4a57-9c34-0de4a3574358" />
