### PR TITLE
Test: Fix failing Unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,7 @@ jobs:
       - name: Check PHP Linting
         run: |
           composer run lint
+
+      - name: Run PHP Unit Tests
+        run: |
+          composer run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           composer run lint
 
+      - name: Run PHP Unit Tests
+        run: |
+          composer run test
+
       - name: Set Git identity
         run: |
           git config user.email "badasswpdev@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.12.0
+* Fix: Enqueuing editor scripts when loaded as `mu-plugin`.
+* Test: Fix failing Unit tests.
+* Tested up to WP 7.0.
+
 ## 1.11.0
 * Feat: Add `More Plugins` options page.
 

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -50,6 +50,7 @@ class Boot extends Service implements Kernel {
 	 * @since 1.0.2 Load asset via plugin directory URL.
 	 * @since 1.2.2 Localise WP version.
 	 * @since 1.7.0 Use webpack generated PHP asset file.
+	 * @since 1.12.0 Replace plugin slug with __DIR__ to get plugin directory path.
 	 *
 	 * @wp-hook 'enqueue_block_editor_assets'
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,11 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.12.0 =
+* Fix: Enqueuing editor scripts when loaded as `mu-plugin`.
+* Test: Fix failing Unit tests.
+* Tested up to WP 7.0.
+
 = 1.11.0 =
 * Feat: Add `More Plugins` options page.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Search and Replace for Block Editor ===
-Contributors: badasswp, rajanand346, jargovi, activist507
+Contributors: badasswp, rajanand346, jargovi, activist507, gonzomir
 Tags: search, replace, text, block, editor.
 Requires at least: 6.0
 Tested up to: 7.0

--- a/src/core/utils.tsx
+++ b/src/core/utils.tsx
@@ -162,7 +162,7 @@ export const getEditorRoot = (): Promise< HTMLElement | Error > => {
 /**
  * Get App Container.
  *
- * Create an DIV container within the Editor root where
+ * Create a DIV container within the Editor root where
  * we will inject our React app.
  *
  * @since 1.2.0

--- a/tests/unit/php/Core/ContainerTest.php
+++ b/tests/unit/php/Core/ContainerTest.php
@@ -14,9 +14,9 @@ use SearchReplaceForBlockEditor\Abstracts\Service;
  * @covers \SearchReplaceForBlockEditor\Core\Container::__construct
  * @covers \SearchReplaceForBlockEditor\Core\Container::register
  * @covers \SearchReplaceForBlockEditor\Services\Admin::register
+ * @covers \SearchReplaceForBlockEditor\Services\Admin::__construct
  * @covers \SearchReplaceForBlockEditor\Services\Boot::register
  * @covers \SearchReplaceForBlockEditor\Abstracts\Service::get_instance
- * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class ContainerTest extends TestCase {
 	public Container $container;

--- a/tests/unit/php/Services/AdminTest.php
+++ b/tests/unit/php/Services/AdminTest.php
@@ -52,6 +52,10 @@ class AdminTest extends WPMockTestCase {
 	}
 
 	public function test_register_options_menu() {
+		$base_64_encoded_for_windows = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj4NCgkJCQkJPHBhdGggZD0iTTEzIDVjLTMuMyAwLTYgMi43LTYgNiAwIDEuNC41IDIuNyAxLjMgMy43bC0zLjggMy44IDEuMSAxLjEgMy44LTMuOGMxIC44IDIuMyAxLjMgMy43IDEuMyAzLjMgMCA2LTIuNyA2LTZTMTYuMyA1IDEzIDV6bTAgMTAuNWMtMi41IDAtNC41LTItNC41LTQuNXMyLTQuNSA0LjUtNC41IDQuNSAyIDQuNSA0LjUtMiA0LjUtNC41IDQuNXoiIC8+DQoJCQkJPC9zdmc+';
+
+		$base_64_encoded_for_non_windows = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj4KCQkJCQk8cGF0aCBkPSJNMTMgNWMtMy4zIDAtNiAyLjctNiA2IDAgMS40LjUgMi43IDEuMyAzLjdsLTMuOCAzLjggMS4xIDEuMSAzLjgtMy44YzEgLjggMi4zIDEuMyAzLjcgMS4zIDMuMyAwIDYtMi43IDYtNlMxNi4zIDUgMTMgNXptMCAxMC41Yy0yLjUgMC00LjUtMi00LjUtNC41czItNC41IDQuNS00LjUgNC41IDIgNC41IDQuNS0yIDQuNS00LjUgNC41eiIgLz4KCQkJCTwvc3ZnPg==';
+
 		WP_Mock::userFunction( 'add_menu_page' )
 			->once()
 			->with(
@@ -60,7 +64,7 @@ class AdminTest extends WPMockTestCase {
 				'manage_options',
 				'search-replace-for-block-editor',
 				[ $this->admin, 'register_options_page' ],
-				'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIj4KCQkJCQk8cGF0aCBkPSJNMTMgNWMtMy4zIDAtNiAyLjctNiA2IDAgMS40LjUgMi43IDEuMyAzLjdsLTMuOCAzLjggMS4xIDEuMSAzLjgtMy44YzEgLjggMi4zIDEuMyAzLjcgMS4zIDMuMyAwIDYtMi43IDYtNlMxNi4zIDUgMTMgNXptMCAxMC41Yy0yLjUgMC00LjUtMi00LjUtNC41czItNC41IDQuNS00LjUgNC41IDIgNC41IDQuNS0yIDQuNS00LjUgNC41eiIgLz4KCQkJCTwvc3ZnPg==',
+				strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ? $base_64_encoded_for_windows : $base_64_encoded_for_non_windows,
 				100
 			)
 			->andReturn( null );

--- a/tests/unit/php/Services/AdminTest.php
+++ b/tests/unit/php/Services/AdminTest.php
@@ -15,13 +15,13 @@ use SearchReplaceForBlockEditor\Services\Admin;
  * @covers \SearchReplaceForBlockEditor\Services\Admin::register_options_menu
  * @covers \SearchReplaceForBlockEditor\Services\Admin::register_options_init
  * @covers \SearchReplaceForBlockEditor\Services\Admin::register_options_styles
+ * @covers \SearchReplaceForBlockEditor\Services\Admin::__construct
  * @covers \SearchReplaceForBlockEditor\Admin\Options::__callStatic
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_fields
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_notice
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_page
  * @covers \SearchReplaceForBlockEditor\Admin\Options::get_form_submit
  * @covers \SearchReplaceForBlockEditor\Admin\Options::init
- * @covers \PingMeOnSlack\Services\Admin::__construct
  */
 class AdminTest extends WPMockTestCase {
 	public Admin $admin;

--- a/tests/unit/php/Services/BootTest.php
+++ b/tests/unit/php/Services/BootTest.php
@@ -78,7 +78,7 @@ class BootTest extends WPMockTestCase {
 			->andReturn( '/var/www/wp-content/plugins/search-replace-for-block-editor/inc/Services/' );
 
 		WP_Mock::userFunction( 'plugins_url' )
-			->with( 'search-replace-for-block-editor/dist/app.js' )
+			->with( 'dist/app.js', dirname( dirname( $boot->getFileName() ) ) )
 			->andReturn( 'https://example.com/wp-content/plugins/search-replace-for-block-editor/dist/app.js' );
 
 		WP_Mock::userFunction( 'wp_enqueue_script' )

--- a/tests/unit/php/Services/BootTest.php
+++ b/tests/unit/php/Services/BootTest.php
@@ -78,7 +78,7 @@ class BootTest extends WPMockTestCase {
 			->andReturn( '/var/www/wp-content/plugins/search-replace-for-block-editor/inc/Services/' );
 
 		WP_Mock::userFunction( 'plugins_url' )
-			->with( 'dist/app.js', dirname( dirname( $boot->getFileName() ) ) )
+			->with( 'dist/app.js', dirname( $boot->getFileName(), 2 ) )
 			->andReturn( 'https://example.com/wp-content/plugins/search-replace-for-block-editor/dist/app.js' );
 
 		WP_Mock::userFunction( 'wp_enqueue_script' )


### PR DESCRIPTION
This PR resolves #98.

## Description / Background Context

This PR addresses failing unit tests related to this [PR's](https://github.com/aw-ng/search-replace-for-block-editor/pull/99) changes.

## Testing Instructions

1. Pull PR to local.
2. Run `composer run test`.
3. Observe that all test cases are passing correctly.

## Screenshots / Screencast

<img width="480" alt="Screenshot 2026-08-12 at 01 05 51" src="https://github.com/user-attachments/assets/37a0f8b6-40b6-4885-b04f-627cfc0ab722" />